### PR TITLE
Guidance for Drug Queries and Remove Outside RP

### DIFF
--- a/exports/test_data/G1_EH_General_Notes.html
+++ b/exports/test_data/G1_EH_General_Notes.html
@@ -481,6 +481,11 @@
                 <div class="divTableCell">Updated column headers in RT2a and RT2b to correctly specify View, Download, and Transmit.</div>
                 <div class="divTableCell">5/5/2021</div>
               </div>
+              <div class="divTableRow">
+                <div class="divTableCell">2.4</div>
+                <div class="divTableCell">Added Guidance to hide Automated Drug Queries for 2021 RT1 tests for Medicare. Removed references to encounters that happen outside Reporting/Performance Period for RT1, RT2, RT3, RT4, RT5, RT6, RT7, RT8, RT9, RT10, RT11, RT12 and RT15.</div>
+                <div class="divTableCell">6/25/2021</div>
+              </div>
           </div>
         </div>
     <script src="https://code.jquery.com/jquery-1.12.4.min.js"></script>

--- a/exports/test_data/G1_EH_Required_Test_1.html
+++ b/exports/test_data/G1_EH_Required_Test_1.html
@@ -446,7 +446,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">New, Within</li></td>
+                          <td class="divTableCell ">New</li></td>
                           <td class="divTableCell ">2</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell automatable2">2</li></td>
@@ -463,7 +463,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">New, Within</li></td>
+                          <td class="divTableCell ">New</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell ">0</li></td>
                           <td class="divTableCell automatable2">1</li></td>
@@ -480,7 +480,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Changed, Within</li></td>
+                          <td class="divTableCell ">Changed</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell automatable2">1</li></td>
@@ -497,7 +497,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Changed, Within</li></td>
+                          <td class="divTableCell ">Changed</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell automatable2">1</li></td>
@@ -514,7 +514,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">New, Within</li></td>
+                          <td class="divTableCell ">New</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell ">2</li></td>
                           <td class="divTableCell automatable2">1</li></td>
@@ -565,7 +565,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">New, Within</li></td>
+                          <td class="divTableCell ">New</li></td>
                           <td class="divTableCell ">2</li></td>
                           <td class="divTableCell automatable2">2</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
@@ -580,7 +580,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">New, Within</li></td>
+                          <td class="divTableCell ">New</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell automatable2">1</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
@@ -595,7 +595,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Changed, Within</li></td>
+                          <td class="divTableCell ">Changed</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell automatable2">1</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
@@ -610,7 +610,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Changed, Within</li></td>
+                          <td class="divTableCell ">Changed</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell automatable2">1</li></td>
                           <td class="divTableCell automatable1">No</li></td>
@@ -625,7 +625,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">New, Within</li></td>
+                          <td class="divTableCell ">New</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell automatable2">1</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
@@ -682,7 +682,7 @@
                             <div class="divSmall">4/23/1967</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">New, Within</li></td>
+                          <td class="divTableCell ">New</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell ">0</li></td>
                           <td class="divTableCell automatable2">1</li></td>
@@ -699,7 +699,7 @@
                             <div class="divSmall">9/25/1972</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">New, Within</li></td>
+                          <td class="divTableCell ">New</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell automatable2">1</li></td>
@@ -716,7 +716,7 @@
                             <div class="divSmall">7/27/1983</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Changed, Within</li></td>
+                          <td class="divTableCell ">Changed</li></td>
                           <td class="divTableCell ">2</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell automatable2">2</li></td>
@@ -733,7 +733,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Changed, Within</li></td>
+                          <td class="divTableCell ">Changed</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell ">2</li></td>
                           <td class="divTableCell automatable2">1</li></td>
@@ -784,7 +784,7 @@
                             <div class="divSmall">4/23/1967</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">New, Within</li></td>
+                          <td class="divTableCell ">New</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell automatable2">1</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
@@ -799,7 +799,7 @@
                             <div class="divSmall">9/25/1972</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">New, Within</li></td>
+                          <td class="divTableCell ">New</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell automatable2">1</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
@@ -814,7 +814,7 @@
                             <div class="divSmall">7/27/1983</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Changed, Within</li></td>
+                          <td class="divTableCell ">Changed</li></td>
                           <td class="divTableCell ">2</li></td>
                           <td class="divTableCell automatable2">2</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
@@ -829,7 +829,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Changed, Within</li></td>
+                          <td class="divTableCell ">Changed</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell automatable2">1</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>

--- a/exports/test_data/G1_EH_Required_Test_1.html
+++ b/exports/test_data/G1_EH_Required_Test_1.html
@@ -364,7 +364,7 @@
             <div class="divTableCell noBorder">2: If a Health IT Module automatically transmits a prescription electronically when it is generated, it is at the discretion of the ATL not to test scenarios that assume this is not automatic.</div>
           </div>
           <div class="divTableNoteRow">
-            <div class="divTableCell noBorder">3: If a Health IT Module automatically queries for a drug formulary upon every prescription that is generated, it is at the discretion of the ATL not to test scenarios that assume this is not automatic.</div>
+            <div class="divTableCell noBorder">3: If a Health IT Module automatically queries for a drug formulary upon every prescription that is generated, it is at the discretion of the ATL not to test scenarios that assume this is not automatic. Additionally, the 2021 specification for Medicare has removed the requirement for formulary checking as part of the calculations.</div>
           </div>
           <div class="divTableNoteRow">
             <div class="divTableCell noBorder">4: If a Health IT Module can only send changes electronically, it is at the discretion of the ATL not to test scenarios that assume a change could be sent via non-electronic means.</div>
@@ -432,7 +432,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Prescriptions  (New, Changed) Written Within or Outside the Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Prescriptions  (New, Changed) Written Within the Reporting Period</th>
                           <th class="divTableCell blueItallic ">Number of Prescriptions Written (not controlled)</th>
                           <th class="divTableCell blueItallic ">Number of Controlled Prescriptions Written</th>
                           <th class="divTableCell blueItallic automatable2">Number of Prescriptions (not controlled) Generated and Transmitted Electronically</th>
@@ -553,7 +553,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Prescriptions  (New, Changed) Written Within or Outside the Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Prescriptions  (New, Changed) Written Within the Reporting Period</th>
                           <th class="divTableCell blueItallic ">Number of Prescriptions Written</th>
                           <th class="divTableCell blueItallic automatable2">Number of Prescriptions Generated and Transmitted Electronically</th>
                           <th class="divTableCell blueItallic automatable1">Prescription(s) Queried for Drug Formulary</th>
@@ -668,7 +668,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Prescriptions  (New, Changed) Written Within or Outside the Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Prescriptions  (New, Changed) Written Within the Reporting Period</th>
                           <th class="divTableCell blueItallic ">Number of Prescriptions Written (not controlled)</th>
                           <th class="divTableCell blueItallic ">Number of Controlled Prescriptions Written</th>
                           <th class="divTableCell blueItallic automatable2">Number of Prescriptions (not controlled) Generated and Transmitted Electronically</th>
@@ -772,7 +772,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Prescriptions  (New, Changed) Written Within or Outside the Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Prescriptions  (New, Changed) Written Within the Reporting Period</th>
                           <th class="divTableCell blueItallic ">Number of Prescriptions Written</th>
                           <th class="divTableCell blueItallic automatable2">Number of Prescriptions Generated and Transmitted Electronically</th>
                           <th class="divTableCell blueItallic automatable1">Prescription(s) Queried for Drug Formulary</th>

--- a/exports/test_data/G1_EH_Required_Test_1.html
+++ b/exports/test_data/G1_EH_Required_Test_1.html
@@ -364,7 +364,7 @@
             <div class="divTableCell noBorder">2: If a Health IT Module automatically transmits a prescription electronically when it is generated, it is at the discretion of the ATL not to test scenarios that assume this is not automatic.</div>
           </div>
           <div class="divTableNoteRow">
-            <div class="divTableCell noBorder">3: If a Health IT Module automatically queries for a drug formulary upon every prescription that is generated, it is at the discretion of the ATL not to test scenarios that assume this is not automatic. Additionally, the 2021 specification for Medicare has removed the requirement for formulary checking as part of the calculations.</div>
+            <div class="divTableCell noBorder">3: If a Health IT Module automatically queries for a drug formulary upon every prescription that is generated, it is at the discretion of the ATL not to test scenarios that assume this is not automatic. Additionally, the 2021 specification for Medicare has removed the requirement for formulary checking as part of the calculations (Select &#39;Hide - Automated Drug Queries&#39; to remove this step from the test data).</div>
           </div>
           <div class="divTableNoteRow">
             <div class="divTableCell noBorder">4: If a Health IT Module can only send changes electronically, it is at the discretion of the ATL not to test scenarios that assume a change could be sent via non-electronic means.</div>

--- a/exports/test_data/G1_EH_Required_Test_10.html
+++ b/exports/test_data/G1_EH_Required_Test_10.html
@@ -364,7 +364,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Medication Orders Created Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Medication Orders Created Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Medication Orders Created</th>
                           <th class="divTableCell blueItallic ">Number of Medication Orders Recorded Using CPOE</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -454,7 +454,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Medication Orders Created Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Medication Orders Created Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Medication Orders Created</th>
                           <th class="divTableCell blueItallic ">Number of Medication Orders Recorded Using CPOE</th>
                         <th class="divTableCell blueItallic">Records Total</th>

--- a/exports/test_data/G1_EH_Required_Test_11.html
+++ b/exports/test_data/G1_EH_Required_Test_11.html
@@ -364,7 +364,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Laboratory Orders Created Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Laboratory Orders Created Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Laboratory Orders Created</th>
                           <th class="divTableCell blueItallic ">Number of Laboratory Orders Recorded Using CPOE</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -454,7 +454,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Laboratory Orders Created Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Laboratory Orders Created Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Laboratory Orders Created</th>
                           <th class="divTableCell blueItallic ">Number of Laboratory Orders Recorded Using CPOE</th>
                         <th class="divTableCell blueItallic">Records Total</th>

--- a/exports/test_data/G1_EH_Required_Test_12.html
+++ b/exports/test_data/G1_EH_Required_Test_12.html
@@ -364,7 +364,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Diagnostic Imaging Orders Created Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Diagnostic Imaging Orders Created Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Diagnostic Imaging Orders Created</th>
                           <th class="divTableCell blueItallic ">Number of Diagnostic Imaging Orders Recorded Using CPOE</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -454,7 +454,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Diagnostic Imaging Orders Created Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Diagnostic Imaging Orders Created Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Diagnostic Imaging Orders Created</th>
                           <th class="divTableCell blueItallic ">Number of Diagnostic Imaging Orders Recorded Using CPOE</th>
                         <th class="divTableCell blueItallic">Records Total</th>

--- a/exports/test_data/G1_EH_Required_Test_15.html
+++ b/exports/test_data/G1_EH_Required_Test_15.html
@@ -389,7 +389,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">3</li></td>
                           <td class="divTableCell ">3</li></td>
                           <td class="divTableCell ">3</li></td>
@@ -402,7 +402,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">2</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell ">2</li></td>
@@ -415,7 +415,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">5</li></td>
                           <td class="divTableCell ">2</li></td>
                           <td class="divTableCell ">2</li></td>
@@ -428,7 +428,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell ">1</li></td>
@@ -441,7 +441,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">2</li></td>
                           <td class="divTableCell ">0</li></td>
                           <td class="divTableCell ">0</li></td>
@@ -493,7 +493,7 @@
                             <div class="divSmall">4/23/1967</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell ">1</li></td>
@@ -506,7 +506,7 @@
                             <div class="divSmall">9/25/1972</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">2</li></td>
                           <td class="divTableCell ">2</li></td>
                           <td class="divTableCell ">2</li></td>
@@ -519,7 +519,7 @@
                             <div class="divSmall">7/27/1983</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">4</li></td>
                           <td class="divTableCell ">3</li></td>
                           <td class="divTableCell ">3</li></td>
@@ -532,7 +532,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">3</li></td>
                           <td class="divTableCell ">3</li></td>
                           <td class="divTableCell ">3</li></td>

--- a/exports/test_data/G1_EH_Required_Test_15.html
+++ b/exports/test_data/G1_EH_Required_Test_15.html
@@ -376,7 +376,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Admitted Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Patient Admitted Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Number of Electronic Summary of Care Records Received</th>
                           <th class="divTableCell blueItallic ">Number of Electronic Summary of Care Records Where Medication Reconciliation Occurred During the Performance Period</th>
                           <th class="divTableCell blueItallic ">Number of Electronic Summary of Care Records Where Medication Allergy Reconciliation Occurred During the Performance Period</th>
@@ -480,7 +480,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Admitted Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Patient Admitted Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Number of Electronic Summary of Care Records Received</th>
                           <th class="divTableCell blueItallic ">Number of Electronic Summary of Care Records Where Medication Reconciliation Occurred During the Performance Period</th>
                           <th class="divTableCell blueItallic ">Number of Electronic Summary of Care Records Where Medication Allergy Reconciliation Occurred During the Performance Period</th>

--- a/exports/test_data/G1_EH_Required_Test_2a_.html
+++ b/exports/test_data/G1_EH_Required_Test_2a_.html
@@ -421,7 +421,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting / Performance Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting / Performance Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient Provided Access to View, Download, and Transmit Their Health Information within 36 hours</th>
                           <th class="divTableCell blueItallic automatable1">Patient Health Information is Available to Access via API within 36 hours</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -432,7 +432,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
@@ -444,7 +444,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
@@ -456,7 +456,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
@@ -468,7 +468,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0</td>
@@ -480,7 +480,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0</td>
@@ -511,7 +511,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting / Performance Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting / Performance Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient Provided Access to View, Download, and Transmit Their Health Information within 36 hours</th>
                           <th class="divTableCell blueItallic automatable1">Patient Health Information is Available to Access via API within 36 hours</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -522,7 +522,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">-1</td>
@@ -534,7 +534,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">-1</td>
@@ -546,7 +546,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">-1</td>
@@ -577,7 +577,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting / Performance Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting / Performance Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient Provided Access to View, Download, and Transmit Their Health Information within 36 hours</th>
                           <th class="divTableCell blueItallic automatable1">Patient Health Information is Available to Access via API within 36 hours</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -588,7 +588,7 @@
                             <div class="divSmall">4/23/1967</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
@@ -600,7 +600,7 @@
                             <div class="divSmall">9/25/1972</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
@@ -612,7 +612,7 @@
                             <div class="divSmall">7/27/1983</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
@@ -643,7 +643,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting / Performance Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting / Performance Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient Provided Access to View, Download, and Transmit Their Health Information within 36 hours</th>
                           <th class="divTableCell blueItallic automatable1">Patient Health Information is Available to Access via API within 36 hours</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -654,7 +654,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0</td>

--- a/exports/test_data/G1_EH_Required_Test_2b_.html
+++ b/exports/test_data/G1_EH_Required_Test_2b_.html
@@ -421,7 +421,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting / Performance Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting / Performance Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient Provided Access to View, Download, and Transmit Their Health Information within 36 hours</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -431,7 +431,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
                                     <td class="divTableCell noWrap automated1_result">1</td>
@@ -442,7 +442,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
                                     <td class="divTableCell noWrap automated1_result">1</td>
@@ -453,7 +453,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
                                     <td class="divTableCell noWrap automated1_result">1</td>
@@ -464,7 +464,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0</td>
                                     <td class="divTableCell noWrap automated1_result">1</td>
@@ -475,7 +475,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
                                     <td class="divTableCell noWrap automated1_result">1</td>
@@ -504,7 +504,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting / Performance Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting / Performance Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient Provided Access to View, Download, and Transmit Their Health Information within 36 hours</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -514,7 +514,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">-1</td>
                                     <td class="divTableCell noWrap automated1_result">0</td>
@@ -525,7 +525,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">-1</td>
                                     <td class="divTableCell noWrap automated1_result">0</td>
@@ -536,7 +536,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">-1</td>
                                     <td class="divTableCell noWrap automated1_result">0</td>
@@ -565,7 +565,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting / Performance Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting / Performance Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient Provided Access to View, Download, and Transmit Their Health Information within 36 hours</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -575,7 +575,7 @@
                             <div class="divSmall">4/23/1967</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
                                     <td class="divTableCell noWrap automated1_result">1</td>
@@ -586,7 +586,7 @@
                             <div class="divSmall">9/25/1972</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
                                     <td class="divTableCell noWrap automated1_result">1</td>
@@ -597,7 +597,7 @@
                             <div class="divSmall">7/27/1983</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
                                     <td class="divTableCell noWrap automated1_result">1</td>
@@ -626,7 +626,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting / Performance Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting / Performance Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient Provided Access to View, Download, and Transmit Their Health Information within 36 hours</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -636,7 +636,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0</td>
                                     <td class="divTableCell noWrap automated1_result">0</td>

--- a/exports/test_data/G1_EH_Required_Test_2c_.html
+++ b/exports/test_data/G1_EH_Required_Test_2c_.html
@@ -421,7 +421,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting / Performance Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting / Performance Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient Health Information is Available to Access via API within 36 hours</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -431,7 +431,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
                                     <td class="divTableCell noWrap automated1_result">1</td>
@@ -442,7 +442,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
                                     <td class="divTableCell noWrap automated1_result">1</td>
@@ -453,7 +453,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
                                     <td class="divTableCell noWrap automated1_result">1</td>
@@ -464,7 +464,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0</td>
                                     <td class="divTableCell noWrap automated1_result">1</td>
@@ -475,7 +475,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
                                     <td class="divTableCell noWrap automated1_result">1</td>
@@ -504,7 +504,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting / Performance Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting / Performance Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient Health Information is Available to Access via API within 36 hours</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -514,7 +514,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">-1</td>
                                     <td class="divTableCell noWrap automated1_result">0</td>
@@ -525,7 +525,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">-1</td>
                                     <td class="divTableCell noWrap automated1_result">0</td>
@@ -536,7 +536,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">-1</td>
                                     <td class="divTableCell noWrap automated1_result">0</td>
@@ -565,7 +565,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting / Performance Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting / Performance Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient Health Information is Available to Access via API within 36 hours</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -575,7 +575,7 @@
                             <div class="divSmall">4/23/1967</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
                                     <td class="divTableCell noWrap automated1_result">1</td>
@@ -586,7 +586,7 @@
                             <div class="divSmall">9/25/1972</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
                                     <td class="divTableCell noWrap automated1_result">1</td>
@@ -597,7 +597,7 @@
                             <div class="divSmall">7/27/1983</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
                                     <td class="divTableCell noWrap automated1_result">1</td>
@@ -626,7 +626,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting / Performance Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting / Performance Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient Health Information is Available to Access via API within 36 hours</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -636,7 +636,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0</td>
                                     <td class="divTableCell noWrap automated1_result">0</td>

--- a/exports/test_data/G1_EH_Required_Test_3.html
+++ b/exports/test_data/G1_EH_Required_Test_3.html
@@ -385,7 +385,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">CEHRT Identifies Patient-Specific Education Resources  During  Calendar Year</th>
                           <th class="divTableCell blueItallic automatable1">EH Provides Electronic Access to Patient-Specific Educational Resources Identified by CEHRT During Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -396,7 +396,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Identified</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0</td>
@@ -408,7 +408,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Not identified</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0</td>
@@ -420,7 +420,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Not identified</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0</td>
@@ -432,7 +432,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Not identified</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0</td>
@@ -444,7 +444,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Identified</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
@@ -475,7 +475,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">CEHRT Identifies Patient-Specific Education Resources  During  Calendar Year</th>
                           <th class="divTableCell blueItallic automatable1">EH Provides Electronic Access to Patient-Specific Educational Resources Identified by CEHRT During Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -486,7 +486,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Identified</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
@@ -498,7 +498,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Identified</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
@@ -510,7 +510,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Identified</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
@@ -541,7 +541,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">CEHRT Identifies Patient-Specific Education Resources  During  Calendar Year</th>
                           <th class="divTableCell blueItallic automatable1">EH Provides Electronic Access to Patient-Specific Educational Resources Identified by CEHRT During Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -552,7 +552,7 @@
                             <div class="divSmall">4/23/1967</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Identified</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
@@ -564,7 +564,7 @@
                             <div class="divSmall">9/25/1972</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Identified</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
@@ -576,7 +576,7 @@
                             <div class="divSmall">7/27/1983</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Identified</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
@@ -607,7 +607,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">CEHRT Identifies Patient-Specific Education Resources  During  Calendar Year</th>
                           <th class="divTableCell blueItallic automatable1">EH Provides Electronic Access to Patient-Specific Educational Resources Identified by CEHRT During Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -618,7 +618,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Identified</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0</td>

--- a/exports/test_data/G1_EH_Required_Test_4a_.html
+++ b/exports/test_data/G1_EH_Required_Test_4a_.html
@@ -379,7 +379,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">Patient or Authorized Representative Viewed (Downloaded or Transmitted) their Information During the Calendar Year</th>
                           <th class="divTableCell blueItallic ">Patient Accessed Health Information Through API During the Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -390,7 +390,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell">0</td>
@@ -401,7 +401,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell">0</td>
@@ -412,7 +412,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell">0</td>
@@ -423,7 +423,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell">1</td>
@@ -434,7 +434,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
@@ -465,7 +465,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">Patient or Authorized Representative Viewed (Downloaded or Transmitted) their Information During the Calendar Year</th>
                           <th class="divTableCell blueItallic ">Patient Accessed Health Information Through API During the Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -476,7 +476,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell">1</td>
@@ -487,7 +487,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
@@ -498,7 +498,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
@@ -529,7 +529,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">Patient or Authorized Representative Viewed (Downloaded or Transmitted) their Information During the Calendar Year</th>
                           <th class="divTableCell blueItallic ">Patient Accessed Health Information Through API During the Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -540,7 +540,7 @@
                             <div class="divSmall">4/23/1967</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell">1</td>
@@ -551,7 +551,7 @@
                             <div class="divSmall">9/25/1972</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
@@ -562,7 +562,7 @@
                             <div class="divSmall">7/27/1983</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
@@ -593,7 +593,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">Patient or Authorized Representative Viewed (Downloaded or Transmitted) their Information During the Calendar Year</th>
                           <th class="divTableCell blueItallic ">Patient Accessed Health Information Through API During the Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -604,7 +604,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell">0</td>

--- a/exports/test_data/G1_EH_Required_Test_4b_.html
+++ b/exports/test_data/G1_EH_Required_Test_4b_.html
@@ -379,7 +379,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">Patient or Authorized Representative Viewed (Downloaded or Transmitted) their Information During the Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -389,7 +389,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell">0</td>
                         </tr>
@@ -399,7 +399,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell">0</td>
                         </tr>
@@ -409,7 +409,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell">0</td>
                         </tr>
@@ -419,7 +419,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -429,7 +429,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -458,7 +458,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">Patient or Authorized Representative Viewed (Downloaded or Transmitted) their Information During the Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -468,7 +468,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -478,7 +478,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -488,7 +488,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -517,7 +517,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">Patient or Authorized Representative Viewed (Downloaded or Transmitted) their Information During the Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -527,7 +527,7 @@
                             <div class="divSmall">4/23/1967</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -537,7 +537,7 @@
                             <div class="divSmall">9/25/1972</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -547,7 +547,7 @@
                             <div class="divSmall">7/27/1983</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -576,7 +576,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">Patient or Authorized Representative Viewed (Downloaded or Transmitted) their Information During the Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -586,7 +586,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">0</td>
                         </tr>

--- a/exports/test_data/G1_EH_Required_Test_4c_.html
+++ b/exports/test_data/G1_EH_Required_Test_4c_.html
@@ -379,7 +379,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">Patient Accessed Health Information Through API During the Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -389,7 +389,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Not accessed</li></td>
                                 <td class="divTableCell">0</td>
                         </tr>
@@ -399,7 +399,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Not accessed</li></td>
                                 <td class="divTableCell">0</td>
                         </tr>
@@ -409,7 +409,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Not accessed</li></td>
                                 <td class="divTableCell">0</td>
                         </tr>
@@ -419,7 +419,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">During</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -429,7 +429,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">During</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -458,7 +458,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">Patient Accessed Health Information Through API During the Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -468,7 +468,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -478,7 +478,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -488,7 +488,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -517,7 +517,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">Patient Accessed Health Information Through API During the Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -527,7 +527,7 @@
                             <div class="divSmall">4/23/1967</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -537,7 +537,7 @@
                             <div class="divSmall">9/25/1972</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -547,7 +547,7 @@
                             <div class="divSmall">7/27/1983</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -576,7 +576,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">Patient Accessed Health Information Through API During the Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -586,7 +586,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">0</td>
                         </tr>

--- a/exports/test_data/G1_EH_Required_Test_5.html
+++ b/exports/test_data/G1_EH_Required_Test_5.html
@@ -391,7 +391,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">Patient or Patient Representative Sends Secure Electronic Message to EH During Calendar Year</th>
                           <th class="divTableCell blueItallic ">EH Replies to Secure Electronic Message from Patient or Patient Representative During Calendar Year</th>
                           <th class="divTableCell blueItallic ">EH Sends Secure Electronic Message to Patient or Patient Representative During Calendar Year</th>
@@ -404,7 +404,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">No</li></td>
@@ -418,7 +418,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">N/A</li></td>
                           <td class="divTableCell ">No</li></td>
@@ -432,7 +432,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">No</li></td>
@@ -446,7 +446,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
@@ -460,7 +460,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">N/A</li></td>
                           <td class="divTableCell ">Yes</li></td>
@@ -495,7 +495,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">Patient or Patient Representative Sends Secure Electronic Message to EH During Calendar Year</th>
                           <th class="divTableCell blueItallic ">EH Replies to Secure Electronic Message from Patient or Patient Representative During Calendar Year</th>
                           <th class="divTableCell blueItallic ">EH Sends Secure Electronic Message to Patient or Patient Representative During Calendar Year</th>
@@ -508,7 +508,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">No</li></td>
@@ -522,7 +522,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">N/A</li></td>
                           <td class="divTableCell ">Yes</li></td>
@@ -536,7 +536,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">N/A</li></td>
                           <td class="divTableCell ">No</li></td>
@@ -571,7 +571,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">Patient or Patient Representative Sends Secure Electronic Message to EH During Calendar Year</th>
                           <th class="divTableCell blueItallic ">EH Replies to Secure Electronic Message from Patient or Patient Representative During Calendar Year</th>
                           <th class="divTableCell blueItallic ">EH Sends Secure Electronic Message to Patient or Patient Representative During Calendar Year</th>
@@ -584,7 +584,7 @@
                             <div class="divSmall">4/23/1967</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
@@ -598,7 +598,7 @@
                             <div class="divSmall">9/25/1972</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">Yes</li></td>
@@ -612,7 +612,7 @@
                             <div class="divSmall">7/27/1983</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">N/A</li></td>
                           <td class="divTableCell ">Yes</li></td>
@@ -647,7 +647,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">Patient or Patient Representative Sends Secure Electronic Message to EH During Calendar Year</th>
                           <th class="divTableCell blueItallic ">EH Replies to Secure Electronic Message from Patient or Patient Representative During Calendar Year</th>
                           <th class="divTableCell blueItallic ">EH Sends Secure Electronic Message to Patient or Patient Representative During Calendar Year</th>
@@ -660,7 +660,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">No</li></td>

--- a/exports/test_data/G1_EH_Required_Test_6.html
+++ b/exports/test_data/G1_EH_Required_Test_6.html
@@ -370,7 +370,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged Within or Outside ReportingPeriod </th>
+                          <th class="divTableCell blueItallic ">Patient Discharged Within Reporting Period </th>
                           <th class="divTableCell blueItallic ">Patient Data From Non-Clinical Settings Captured During Reporting Period</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -380,7 +380,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell">0</td>
                         </tr>
@@ -390,7 +390,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell">0</td>
                         </tr>
@@ -400,7 +400,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell">0</td>
                         </tr>
@@ -410,7 +410,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -420,7 +420,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -449,7 +449,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged Within or Outside ReportingPeriod </th>
+                          <th class="divTableCell blueItallic ">Patient Discharged Within Reporting Period </th>
                           <th class="divTableCell blueItallic ">Patient Data From Non-Clinical Settings Captured During Reporting Period</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -459,7 +459,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -469,7 +469,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -479,7 +479,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -508,7 +508,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged Within or Outside ReportingPeriod </th>
+                          <th class="divTableCell blueItallic ">Patient Discharged Within Reporting Period </th>
                           <th class="divTableCell blueItallic ">Patient Data From Non-Clinical Settings Captured During Reporting Period</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -518,7 +518,7 @@
                             <div class="divSmall">4/23/1967</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -528,7 +528,7 @@
                             <div class="divSmall">9/25/1972</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -538,7 +538,7 @@
                             <div class="divSmall">7/27/1983</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -567,7 +567,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged Within or Outside ReportingPeriod </th>
+                          <th class="divTableCell blueItallic ">Patient Discharged Within Reporting Period </th>
                           <th class="divTableCell blueItallic ">Patient Data From Non-Clinical Settings Captured During Reporting Period</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -577,7 +577,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">0</td>
                         </tr>

--- a/exports/test_data/G1_EH_Required_Test_7.html
+++ b/exports/test_data/G1_EH_Required_Test_7.html
@@ -397,7 +397,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Transition of Care or Referral Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Transition of Care or Referral Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Summary of Care Record (including all CMS required information or indication of none) Created and Transmitted / Exchanged Electronically During Calendar Year</th>
                           <th class="divTableCell blueItallic ">Receipt of Summary of Care Record Confirmed During Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -487,7 +487,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Transition of Care or Referral Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Transition of Care or Referral Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Summary of Care Record (including all CMS required information or indication of none) Created and Transmitted / Exchanged Electronically During Calendar Year</th>
                           <th class="divTableCell blueItallic ">Receipt of Summary of Care Record Confirmed During Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>

--- a/exports/test_data/G1_EH_Required_Test_8.html
+++ b/exports/test_data/G1_EH_Required_Test_8.html
@@ -388,7 +388,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Admitted Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Patient Admitted Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Summary of Care Record Requested and Available or Unavailable During Calendar Year</th>
                           <th class="divTableCell blueItallic ">Summary of Care Record Received through Request or Retrieval During Calendar Year</th>
                           <th class="divTableCell blueItallic automatable1">Summary of Care Record Incorporated During Calendar Year</th>
@@ -489,7 +489,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Admitted Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Patient Admitted Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Summary of Care Record Requested and Available or Unavailable During Calendar Year</th>
                           <th class="divTableCell blueItallic ">Summary of Care Record Received through Request or Retrieval During Calendar Year</th>
                           <th class="divTableCell blueItallic automatable1">Summary of Care Record Incorporated During Calendar Year</th>

--- a/exports/test_data/G1_EH_Required_Test_8.html
+++ b/exports/test_data/G1_EH_Required_Test_8.html
@@ -400,7 +400,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">Available</li></td>
                           <td class="divTableCell ">Not Received</li></td>
                           <td class="divTableCell automatable1">Not Incorporated</li></td>
@@ -413,7 +413,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">Unavailable</li></td>
                           <td class="divTableCell ">N/A</li></td>
                           <td class="divTableCell automatable1">N/A</li></td>
@@ -426,7 +426,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">Available</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell automatable1">Not Incorporated</li></td>
@@ -439,7 +439,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">Available</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
@@ -452,7 +452,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">Available</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
@@ -501,7 +501,7 @@
                             <div class="divSmall">4/23/1967</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">Available</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
@@ -514,7 +514,7 @@
                             <div class="divSmall">9/25/1972</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">Available</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
@@ -527,7 +527,7 @@
                             <div class="divSmall">7/27/1983</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">Available</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
@@ -540,7 +540,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">Available</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>

--- a/exports/test_data/G1_EH_Required_Test_9.html
+++ b/exports/test_data/G1_EH_Required_Test_9.html
@@ -370,7 +370,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Admitted Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Patient Admitted Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Medication Reconciliation Performed During the Calendar Year</th>
                           <th class="divTableCell blueItallic ">Medication Allergy Reconciliation Performed During the Calendar Year</th>
                           <th class="divTableCell blueItallic ">Current Problem List Reconciliation Performed During the Calendar Year</th>
@@ -467,7 +467,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Admitted Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Patient Admitted Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Medication Reconciliation Performed During the Calendar Year</th>
                           <th class="divTableCell blueItallic ">Medication Allergy Reconciliation Performed During the Calendar Year</th>
                           <th class="divTableCell blueItallic ">Current Problem List Reconciliation Performed During the Calendar Year</th>

--- a/exports/test_data/G1_EH_Required_Test_9.html
+++ b/exports/test_data/G1_EH_Required_Test_9.html
@@ -382,7 +382,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
@@ -394,7 +394,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">No</li></td>
@@ -406,7 +406,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">No</li></td>
@@ -418,7 +418,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">Yes</li></td>
@@ -430,7 +430,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
@@ -479,7 +479,7 @@
                             <div class="divSmall">4/23/1967</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
@@ -491,7 +491,7 @@
                             <div class="divSmall">9/25/1972</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
@@ -503,7 +503,7 @@
                             <div class="divSmall">7/27/1983</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
@@ -515,7 +515,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>

--- a/exports/test_data/G1_EP_General_Notes.html
+++ b/exports/test_data/G1_EP_General_Notes.html
@@ -484,6 +484,11 @@
                 <div class="divTableCell">Removed column in RT2b for Available to Access via API.</div>
                 <div class="divTableCell">5/5/2021</div>
               </div>
+              <div class="divTableRow">
+                <div class="divTableCell">2.4</div>
+                <div class="divTableCell">Added Guidance to hide Automated Drug Queries for 2021 RT1 tests for MIPS. Removed references to encounters that happen outside Reporting/Performance Period for RT1, RT2, RT3, RT4, RT5, RT6, RT7, RT8, RT9, RT10, RT11, RT12 and RT15.</div>
+                <div class="divTableCell">6/25/2021</div>
+              </div>
           </div>
         </div>
     <script src="https://code.jquery.com/jquery-1.12.4.min.js"></script>

--- a/exports/test_data/G1_EP_Required_Test_1.html
+++ b/exports/test_data/G1_EP_Required_Test_1.html
@@ -364,7 +364,7 @@
             <div class="divTableCell noBorder">2: If a Health IT Module automatically transmits a prescription electronically when it is generated, it is at the discretion of the ATL not to test scenarios that assume this is not automatic.</div>
           </div>
           <div class="divTableNoteRow">
-            <div class="divTableCell noBorder">3: If a Health IT Module automatically queries for a drug formulary upon every prescription that is generated, it is at the discretion of the ATL not to test scenarios that assume this is not automatic. Additionally, the 2021 specification for MIPS has removed the requirement for formulary checking as part of the calculations.</div>
+            <div class="divTableCell noBorder">3: If a Health IT Module automatically queries for a drug formulary upon every prescription that is generated, it is at the discretion of the ATL not to test scenarios that assume this is not automatic. Additionally, the 2021 specification for MIPS has removed the requirement for formulary checking as part of the calculations (Select &#39;Hide - Automated Drug Queries&#39; to remove this step from the test data).</div>
           </div>
           <div class="divTableNoteRow">
             <div class="divTableCell noBorder">4: If a Health IT Module can only send changes electronically, it is at the discretion of the ATL not to test scenarios that assume a change could be sent via non-electronic means.  </div>

--- a/exports/test_data/G1_EP_Required_Test_1.html
+++ b/exports/test_data/G1_EP_Required_Test_1.html
@@ -432,8 +432,8 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Number of Prescriptions Written during reporting/ performance period (not controlled)</th>
-                          <th class="divTableCell blueItallic ">Number of Controlled Prescriptions Written during reporting/  performance period</th>
+                          <th class="divTableCell blueItallic ">Number of Prescriptions Written During Reporting / Performance Period (not controlled)</th>
+                          <th class="divTableCell blueItallic ">Number of Controlled Prescriptions Written During Reporting / Performance Period </th>
                           <th class="divTableCell blueItallic automatable2">Number of Prescriptions (not controlled) Generated and Transmitted Electronically</th>
                           <th class="divTableCell blueItallic automatable2">Number of Controlled Substances Generated and Transmitted Electronically</th>
                           <th class="divTableCell blueItallic automatable1">Prescription(s) Queried for Drug Formulary</th>
@@ -546,7 +546,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Number of Prescriptions Written during reporting/ performance period (not controlled)</th>
+                          <th class="divTableCell blueItallic ">Number of Prescriptions Written During Reporting / Performance Period (not controlled)</th>
                           <th class="divTableCell blueItallic automatable2">Number of Prescriptions (not controlled) Generated and Transmitted Electronically</th>
                           <th class="divTableCell blueItallic automatable1">Prescription(s) Queried for Drug Formulary</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -654,8 +654,8 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Number of Prescriptions Written during reporting/ performance period (not controlled)</th>
-                          <th class="divTableCell blueItallic ">Number of Controlled Prescriptions Written during reporting/  performance period</th>
+                          <th class="divTableCell blueItallic ">Number of Prescriptions Written During Reporting / Performance Period (not controlled)</th>
+                          <th class="divTableCell blueItallic ">Number of Controlled Prescriptions Written During Reporting / Performance Period </th>
                           <th class="divTableCell blueItallic automatable2">Number of Prescriptions (not controlled) Generated and Transmitted Electronically</th>
                           <th class="divTableCell blueItallic automatable2">Number of Controlled Substances Generated and Transmitted Electronically</th>
                           <th class="divTableCell blueItallic automatable1">Prescription(s) Queried for Drug Formulary</th>
@@ -752,7 +752,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Number of Prescriptions Written during reporting/ performance period (not controlled)</th>
+                          <th class="divTableCell blueItallic ">Number of Prescriptions Written During Reporting / Performance Period (not controlled)</th>
                           <th class="divTableCell blueItallic automatable2">Number of Prescriptions (not controlled) Generated and Transmitted Electronically</th>
                           <th class="divTableCell blueItallic automatable1">Prescription(s) Queried for Drug Formulary</th>
                         <th class="divTableCell blueItallic">Records Total</th>

--- a/exports/test_data/G1_EP_Required_Test_1.html
+++ b/exports/test_data/G1_EP_Required_Test_1.html
@@ -364,7 +364,7 @@
             <div class="divTableCell noBorder">2: If a Health IT Module automatically transmits a prescription electronically when it is generated, it is at the discretion of the ATL not to test scenarios that assume this is not automatic.</div>
           </div>
           <div class="divTableNoteRow">
-            <div class="divTableCell noBorder">3: If a Health IT Module automatically queries for a drug formulary upon every prescription that is generated, it is at the discretion of the ATL not to test scenarios that assume this is not automatic.</div>
+            <div class="divTableCell noBorder">3: If a Health IT Module automatically queries for a drug formulary upon every prescription that is generated, it is at the discretion of the ATL not to test scenarios that assume this is not automatic. Additionally, the 2021 specification for MIPS has removed the requirement for formulary checking as part of the calculations.</div>
           </div>
           <div class="divTableNoteRow">
             <div class="divTableCell noBorder">4: If a Health IT Module can only send changes electronically, it is at the discretion of the ATL not to test scenarios that assume a change could be sent via non-electronic means.  </div>

--- a/exports/test_data/G1_EP_Required_Test_10.html
+++ b/exports/test_data/G1_EP_Required_Test_10.html
@@ -364,7 +364,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Medication Orders Created Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Medication Orders Created Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Medication Orders Created</th>
                           <th class="divTableCell blueItallic ">Number of Medication Orders Recorded Using CPOE</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -454,7 +454,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Medication Orders Created Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Medication Orders Created Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Medication Orders Created</th>
                           <th class="divTableCell blueItallic ">Number of Medication Orders Recorded Using CPOE</th>
                         <th class="divTableCell blueItallic">Records Total</th>

--- a/exports/test_data/G1_EP_Required_Test_11.html
+++ b/exports/test_data/G1_EP_Required_Test_11.html
@@ -364,7 +364,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Laboratory Orders Created Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Laboratory Orders Created Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Laboratory Orders Created</th>
                           <th class="divTableCell blueItallic ">Number of Laboratory Orders Recorded Using CPOE</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -454,7 +454,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Laboratory Orders Created Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Laboratory Orders Created Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Laboratory Orders Created</th>
                           <th class="divTableCell blueItallic ">Number of Laboratory Orders Recorded Using CPOE</th>
                         <th class="divTableCell blueItallic">Records Total</th>

--- a/exports/test_data/G1_EP_Required_Test_12.html
+++ b/exports/test_data/G1_EP_Required_Test_12.html
@@ -364,7 +364,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Diagnostic Imaging Orders Created Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Diagnostic Imaging Orders Created Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Diagnostic Imaging Orders Created</th>
                           <th class="divTableCell blueItallic ">Number of Diagnostic Imaging Orders Recorded Using CPOE</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -454,7 +454,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Diagnostic Imaging Orders Created Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Diagnostic Imaging Orders Created Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Diagnostic Imaging Orders Created</th>
                           <th class="divTableCell blueItallic ">Number of Diagnostic Imaging Orders Recorded Using CPOE</th>
                         <th class="divTableCell blueItallic">Records Total</th>

--- a/exports/test_data/G1_EP_Required_Test_2a_.html
+++ b/exports/test_data/G1_EP_Required_Test_2a_.html
@@ -418,7 +418,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Seen  During or Outside EHR Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Patient Seen During EHR Reporting Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient or Authorized Representative Provided Access to View, Download, and Transmit Their Health Information within 48 hours (Medicaid) or 4 business days (MIPS)</th>
                           <th class="divTableCell blueItallic automatable1">Patient Health Information is Available to Access via API  within 48 hours (Medicaid) or 4 business days (MIPS)</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -429,7 +429,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
@@ -441,7 +441,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
@@ -453,7 +453,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0</td>
@@ -465,7 +465,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0</td>
@@ -477,7 +477,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
@@ -512,7 +512,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Seen  During or Outside EHR Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Patient Seen During EHR Reporting Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient or Authorized Representative Provided Access to View, Download, and Transmit Their Health Information within 48 hours (Medicaid) or 4 business days (MIPS)</th>
                           <th class="divTableCell blueItallic automatable1">Patient Health Information is Available to Access via API  within 48 hours (Medicaid) or 4 business days (MIPS)</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -523,7 +523,7 @@
                             <div class="divSmall">4/23/1967</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
@@ -535,7 +535,7 @@
                             <div class="divSmall">7/27/1983</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
@@ -547,7 +547,7 @@
                             <div class="divSmall">9/6/1983</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
@@ -578,7 +578,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Seen  During or Outside EHR Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Patient Seen During EHR Reporting Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient or Authorized Representative Provided Access to View, Download, and Transmit Their Health Information within 48 hours (Medicaid) or 4 business days (MIPS)</th>
                           <th class="divTableCell blueItallic automatable1">Patient Health Information is Available to Access via API  within 48 hours (Medicaid) or 4 business days (MIPS)</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -589,7 +589,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second encounter, during</li></td>
+                          <td class="divTableCell ">Second encounter</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0</td>

--- a/exports/test_data/G1_EP_Required_Test_2b_.html
+++ b/exports/test_data/G1_EP_Required_Test_2b_.html
@@ -418,7 +418,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Seen  During or Outside EHR Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Patient Seen During EHR Reporting Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient or Authorized Representative Provided Access to View, Download, and Transmit Their Health Information within 48 hours (Medicaid) or 4 business days (MIPS)</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -428,7 +428,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
                                     <td class="divTableCell noWrap automated1_result">1</td>
@@ -439,7 +439,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
                                     <td class="divTableCell noWrap automated1_result">1</td>
@@ -450,7 +450,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0</td>
                                     <td class="divTableCell noWrap automated1_result">1</td>
@@ -461,7 +461,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
                                     <td class="divTableCell noWrap automated1_result">1</td>
@@ -472,7 +472,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
                                     <td class="divTableCell noWrap automated1_result">1</td>
@@ -505,7 +505,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Seen  During or Outside EHR Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Patient Seen During EHR Reporting Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient or Authorized Representative Provided Access to View, Download, and Transmit Their Health Information within 48 hours (Medicaid) or 4 business days (MIPS)</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -515,7 +515,7 @@
                             <div class="divSmall">4/23/1967</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
                                     <td class="divTableCell noWrap automated1_result">1</td>
@@ -526,7 +526,7 @@
                             <div class="divSmall">7/27/1983</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
                                     <td class="divTableCell noWrap automated1_result">1</td>
@@ -537,7 +537,7 @@
                             <div class="divSmall">9/6/1983</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
                                     <td class="divTableCell noWrap automated1_result">1</td>
@@ -566,7 +566,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Seen  During or Outside EHR Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Patient Seen During EHR Reporting Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient or Authorized Representative Provided Access to View, Download, and Transmit Their Health Information within 48 hours (Medicaid) or 4 business days (MIPS)</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -576,7 +576,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second encounter, during</li></td>
+                          <td class="divTableCell ">Second encounter</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0</td>
                                     <td class="divTableCell noWrap automated1_result">0</td>

--- a/exports/test_data/G1_EP_Required_Test_2c_.html
+++ b/exports/test_data/G1_EP_Required_Test_2c_.html
@@ -418,7 +418,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Seen  During or Outside EHR Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Patient Seen During EHR Reporting Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient Health Information is Available to Access via API  within 48 hours (Medicaid) or 4 business days (MIPS)</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -428,7 +428,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
                                     <td class="divTableCell noWrap automated1_result">1</td>
@@ -439,7 +439,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
                                     <td class="divTableCell noWrap automated1_result">1</td>
@@ -450,7 +450,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0</td>
                                     <td class="divTableCell noWrap automated1_result">1</td>
@@ -461,7 +461,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
                                     <td class="divTableCell noWrap automated1_result">1</td>
@@ -472,7 +472,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
                                     <td class="divTableCell noWrap automated1_result">1</td>
@@ -505,7 +505,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Seen  During or Outside EHR Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Patient Seen During EHR Reporting Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient Health Information is Available to Access via API  within 48 hours (Medicaid) or 4 business days (MIPS)</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -515,7 +515,7 @@
                             <div class="divSmall">4/23/1967</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
                                     <td class="divTableCell noWrap automated1_result">1</td>
@@ -526,7 +526,7 @@
                             <div class="divSmall">7/27/1983</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
                                     <td class="divTableCell noWrap automated1_result">1</td>
@@ -537,7 +537,7 @@
                             <div class="divSmall">9/6/1983</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
                                     <td class="divTableCell noWrap automated1_result">1</td>
@@ -566,7 +566,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Seen  During or Outside EHR Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Patient Seen During EHR Reporting Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient Health Information is Available to Access via API  within 48 hours (Medicaid) or 4 business days (MIPS)</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -576,7 +576,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second encounter, during</li></td>
+                          <td class="divTableCell ">Second encounter</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0</td>
                                     <td class="divTableCell noWrap automated1_result">0</td>

--- a/exports/test_data/G1_EP_Required_Test_3.html
+++ b/exports/test_data/G1_EP_Required_Test_3.html
@@ -388,9 +388,9 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Seen During or Outside of Reporting / Performance Period</th>
-                          <th class="divTableCell blueItallic ">CEHRT Identifies Patient-Specific Education Resources  During or Outside Reporting/Performance Period</th>
-                          <th class="divTableCell blueItallic automatable1">EP/EC Provides Electronic Access to Patient-Specific Educational Resources Identified by CEHRT During or Outside Reporting/Performance Period</th>
+                          <th class="divTableCell blueItallic ">Patient Seen During Reporting / Performance Period</th>
+                          <th class="divTableCell blueItallic ">CEHRT Identifies Patient-Specific Education Resources  During Reporting/Performance Period</th>
+                          <th class="divTableCell blueItallic automatable1">EP/EC Provides Electronic Access to Patient-Specific Educational Resources Identified by CEHRT During Reporting/Performance Period</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
                         <tr class="divTableAlternatingRow">
@@ -399,7 +399,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell automatable1">Provided</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
@@ -411,7 +411,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell automatable1">Not Provided</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0</td>
@@ -423,7 +423,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell automatable1">Not Provided</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0</td>
@@ -435,7 +435,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell automatable1">Provided</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
@@ -447,7 +447,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell automatable1">Provided</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
@@ -482,9 +482,9 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Seen During or Outside of Reporting / Performance Period</th>
-                          <th class="divTableCell blueItallic ">CEHRT Identifies Patient-Specific Education Resources  During or Outside Reporting/Performance Period</th>
-                          <th class="divTableCell blueItallic automatable1">EP/EC Provides Electronic Access to Patient-Specific Educational Resources Identified by CEHRT During or Outside Reporting/Performance Period</th>
+                          <th class="divTableCell blueItallic ">Patient Seen During Reporting / Performance Period</th>
+                          <th class="divTableCell blueItallic ">CEHRT Identifies Patient-Specific Education Resources  During Reporting/Performance Period</th>
+                          <th class="divTableCell blueItallic automatable1">EP/EC Provides Electronic Access to Patient-Specific Educational Resources Identified by CEHRT During Reporting/Performance Period</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
                         <tr class="divTableAlternatingRow">
@@ -493,7 +493,7 @@
                             <div class="divSmall">4/23/1967</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell automatable1">Provided</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
@@ -505,7 +505,7 @@
                             <div class="divSmall">7/27/1983</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell automatable1">Provided</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
@@ -517,7 +517,7 @@
                             <div class="divSmall">9/6/1983</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell automatable1">Provided</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1</td>
@@ -548,9 +548,9 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Seen During or Outside of Reporting / Performance Period</th>
-                          <th class="divTableCell blueItallic ">CEHRT Identifies Patient-Specific Education Resources  During or Outside Reporting/Performance Period</th>
-                          <th class="divTableCell blueItallic automatable1">EP/EC Provides Electronic Access to Patient-Specific Educational Resources Identified by CEHRT During or Outside Reporting/Performance Period</th>
+                          <th class="divTableCell blueItallic ">Patient Seen During Reporting / Performance Period</th>
+                          <th class="divTableCell blueItallic ">CEHRT Identifies Patient-Specific Education Resources  During Reporting/Performance Period</th>
+                          <th class="divTableCell blueItallic automatable1">EP/EC Provides Electronic Access to Patient-Specific Educational Resources Identified by CEHRT During Reporting/Performance Period</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
                         <tr class="divTableAlternatingRow">
@@ -559,7 +559,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second encounter, during</li></td>
+                          <td class="divTableCell ">Second encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell automatable1">Provided</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0</td>

--- a/exports/test_data/G1_EP_Required_Test_4a_.html
+++ b/exports/test_data/G1_EP_Required_Test_4a_.html
@@ -382,7 +382,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Seen During or Outside Reporting Period </th>
+                          <th class="divTableCell blueItallic ">Patient Seen During Reporting Period </th>
                           <th class="divTableCell blueItallic ">Patient or Authorized Representative Viewed, Downloaded, or Transmitted their Information During Reporting/Performance Period</th>
                           <th class="divTableCell blueItallic ">Patient Accessed Health Information Through API During Reporting/ Performance Period</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -393,7 +393,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell">0</td>
@@ -404,7 +404,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell">0</td>
@@ -415,7 +415,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell">0</td>
@@ -426,7 +426,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
@@ -437,7 +437,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
@@ -468,7 +468,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Seen During or Outside Reporting Period </th>
+                          <th class="divTableCell blueItallic ">Patient Seen During Reporting Period </th>
                           <th class="divTableCell blueItallic ">Patient or Authorized Representative Viewed, Downloaded, or Transmitted their Information During Reporting/Performance Period</th>
                           <th class="divTableCell blueItallic ">Patient Accessed Health Information Through API During Reporting/ Performance Period</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -479,7 +479,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second encounter, during</li></td>
+                          <td class="divTableCell ">Second encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell">1</td>
@@ -490,7 +490,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second encounter, during</li></td>
+                          <td class="divTableCell ">Second encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
@@ -501,7 +501,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second encounter, during</li></td>
+                          <td class="divTableCell ">Second encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell">1</td>
@@ -532,7 +532,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Seen During or Outside Reporting Period </th>
+                          <th class="divTableCell blueItallic ">Patient Seen During Reporting Period </th>
                           <th class="divTableCell blueItallic ">Patient or Authorized Representative Viewed, Downloaded, or Transmitted their Information During Reporting/Performance Period</th>
                           <th class="divTableCell blueItallic ">Patient Accessed Health Information Through API During Reporting/ Performance Period</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -543,7 +543,7 @@
                             <div class="divSmall">4/23/1967</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell">1</td>
@@ -554,7 +554,7 @@
                             <div class="divSmall">7/27/1983</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
@@ -565,7 +565,7 @@
                             <div class="divSmall">9/6/1983</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell">1</td>
@@ -596,7 +596,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Seen During or Outside Reporting Period </th>
+                          <th class="divTableCell blueItallic ">Patient Seen During Reporting Period </th>
                           <th class="divTableCell blueItallic ">Patient or Authorized Representative Viewed, Downloaded, or Transmitted their Information During Reporting/Performance Period</th>
                           <th class="divTableCell blueItallic ">Patient Accessed Health Information Through API During Reporting/ Performance Period</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -607,7 +607,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second encounter, during</li></td>
+                          <td class="divTableCell ">Second encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell">0</td>

--- a/exports/test_data/G1_EP_Required_Test_4b_.html
+++ b/exports/test_data/G1_EP_Required_Test_4b_.html
@@ -379,7 +379,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Seen During or Outside Reporting Period </th>
+                          <th class="divTableCell blueItallic ">Patient Seen During Reporting Period </th>
                           <th class="divTableCell blueItallic ">Patient or Authorized Representative Viewed, Downloaded, or Transmitted their Information During Reporting/Performance Period</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -389,7 +389,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell">0</td>
                         </tr>
@@ -399,7 +399,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell">0</td>
                         </tr>
@@ -409,7 +409,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell">0</td>
                         </tr>
@@ -419,7 +419,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -429,7 +429,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -458,7 +458,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Seen During or Outside Reporting Period </th>
+                          <th class="divTableCell blueItallic ">Patient Seen During Reporting Period </th>
                           <th class="divTableCell blueItallic ">Patient or Authorized Representative Viewed, Downloaded, or Transmitted their Information During Reporting/Performance Period</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -468,7 +468,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second encounter, during</li></td>
+                          <td class="divTableCell ">Second encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -478,7 +478,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second encounter, during</li></td>
+                          <td class="divTableCell ">Second encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -488,7 +488,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second encounter, during</li></td>
+                          <td class="divTableCell ">Second encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -517,7 +517,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Seen During or Outside Reporting Period </th>
+                          <th class="divTableCell blueItallic ">Patient Seen During Reporting Period </th>
                           <th class="divTableCell blueItallic ">Patient or Authorized Representative Viewed, Downloaded, or Transmitted their Information During Reporting/Performance Period</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -527,7 +527,7 @@
                             <div class="divSmall">4/23/1967</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -537,7 +537,7 @@
                             <div class="divSmall">7/27/1983</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -547,7 +547,7 @@
                             <div class="divSmall">9/6/1983</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -576,7 +576,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Seen During or Outside Reporting Period </th>
+                          <th class="divTableCell blueItallic ">Patient Seen During Reporting Period </th>
                           <th class="divTableCell blueItallic ">Patient or Authorized Representative Viewed, Downloaded, or Transmitted their Information During Reporting/Performance Period</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -586,7 +586,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second encounter, during</li></td>
+                          <td class="divTableCell ">Second encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">0</td>
                         </tr>

--- a/exports/test_data/G1_EP_Required_Test_4c_.html
+++ b/exports/test_data/G1_EP_Required_Test_4c_.html
@@ -382,7 +382,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Seen During or Outside Reporting Period </th>
+                          <th class="divTableCell blueItallic ">Patient Seen During Reporting Period </th>
                           <th class="divTableCell blueItallic ">Patient Accessed Health Information Through API During Reporting/ Performance Period</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -392,7 +392,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell">0</td>
                         </tr>
@@ -402,7 +402,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell">0</td>
                         </tr>
@@ -412,7 +412,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell">0</td>
                         </tr>
@@ -422,7 +422,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -432,7 +432,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -461,7 +461,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Seen During or Outside Reporting Period </th>
+                          <th class="divTableCell blueItallic ">Patient Seen During Reporting Period </th>
                           <th class="divTableCell blueItallic ">Patient Accessed Health Information Through API During Reporting/ Performance Period</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -471,7 +471,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second encounter, during</li></td>
+                          <td class="divTableCell ">Second encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -481,7 +481,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second encounter, during</li></td>
+                          <td class="divTableCell ">Second encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -491,7 +491,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second encounter, during</li></td>
+                          <td class="divTableCell ">Second encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -520,7 +520,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Seen During or Outside Reporting Period </th>
+                          <th class="divTableCell blueItallic ">Patient Seen During Reporting Period </th>
                           <th class="divTableCell blueItallic ">Patient Accessed Health Information Through API During Reporting/ Performance Period</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -530,7 +530,7 @@
                             <div class="divSmall">4/23/1967</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -540,7 +540,7 @@
                             <div class="divSmall">7/27/1983</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -550,7 +550,7 @@
                             <div class="divSmall">9/6/1983</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -579,7 +579,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Seen During or Outside Reporting Period </th>
+                          <th class="divTableCell blueItallic ">Patient Seen During Reporting Period </th>
                           <th class="divTableCell blueItallic ">Patient Accessed Health Information Through API During Reporting/ Performance Period</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -589,7 +589,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second encounter, during</li></td>
+                          <td class="divTableCell ">Second encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">0</td>
                         </tr>

--- a/exports/test_data/G1_EP_Required_Test_5.html
+++ b/exports/test_data/G1_EP_Required_Test_5.html
@@ -391,7 +391,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Seen  During or Outside Reporting/Performance Period</th>
+                          <th class="divTableCell blueItallic ">Patient Seen During Reporting/Performance Period</th>
                           <th class="divTableCell blueItallic ">Patient or Patient Representative Sends Secure Electronic Message to EP/EC During the Calendar Year</th>
                           <th class="divTableCell blueItallic ">EP/EC Replies to Secure Electronic Message from Patient or Patient Representative During the Calendar Year</th>
                           <th class="divTableCell blueItallic ">EP/EC Sends Secure Electronic Message to Patient or Patient Representative During the Calendar Year</th>
@@ -404,7 +404,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">No</li></td>
@@ -418,7 +418,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">N/A</li></td>
                           <td class="divTableCell ">No</li></td>
@@ -432,7 +432,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">N/A</li></td>
                           <td class="divTableCell ">No</li></td>
@@ -446,7 +446,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">No</li></td>
@@ -460,7 +460,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">N/A</li></td>
                           <td class="divTableCell ">No</li></td>
@@ -495,7 +495,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Seen  During or Outside Reporting/Performance Period</th>
+                          <th class="divTableCell blueItallic ">Patient Seen During Reporting/Performance Period</th>
                           <th class="divTableCell blueItallic ">Patient or Patient Representative Sends Secure Electronic Message to EP/EC During the Calendar Year</th>
                           <th class="divTableCell blueItallic ">EP/EC Replies to Secure Electronic Message from Patient or Patient Representative During the Calendar Year</th>
                           <th class="divTableCell blueItallic ">EP/EC Sends Secure Electronic Message to Patient or Patient Representative During the Calendar Year</th>
@@ -508,7 +508,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second encounter, during</li></td>
+                          <td class="divTableCell ">Second encounter</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">N/A</li></td>
                           <td class="divTableCell ">Yes</li></td>
@@ -522,7 +522,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second encounter, during</li></td>
+                          <td class="divTableCell ">Second encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">No</li></td>
@@ -536,7 +536,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second encounter, during</li></td>
+                          <td class="divTableCell ">Second encounter</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">N/A</li></td>
                           <td class="divTableCell ">Yes</li></td>
@@ -558,7 +558,7 @@
                   </table>
                 </div>
             
-                <button type="button" class="collapsible ckeditor-accordion-toggle">Scenario 3 - Patient Seen  During or Outside Reporting/Performance Period</button>
+                <button type="button" class="collapsible ckeditor-accordion-toggle">Scenario 3 - Patient Seen During Reporting/Performance Period</button>
                 <div class="content">
                   
                   <table class="divTable">
@@ -571,7 +571,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Seen During or Outside Reporting Period </th>
+                          <th class="divTableCell blueItallic ">Patient Seen During Reporting Period </th>
                           <th class="divTableCell blueItallic ">Patient or Patient Representative Sends Secure Electronic Message to EP/EC During the Calendar Year</th>
                           <th class="divTableCell blueItallic ">EP/EC Replies to Secure Electronic Message from Patient or Patient Representative During the Calendar Year</th>
                           <th class="divTableCell blueItallic ">EP/EC Sends Secure Electronic Message to Patient or Patient Representative During the Calendar Year</th>
@@ -584,7 +584,7 @@
                             <div class="divSmall">4/23/1967</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">No</li></td>
@@ -598,7 +598,7 @@
                             <div class="divSmall">7/27/1983</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">N/A</li></td>
                           <td class="divTableCell ">Yes</li></td>
@@ -612,7 +612,7 @@
                             <div class="divSmall">9/6/1983</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">No</li></td>
@@ -647,7 +647,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Seen  During or Outside Reporting/Performance Period</th>
+                          <th class="divTableCell blueItallic ">Patient Seen During Reporting/Performance Period</th>
                           <th class="divTableCell blueItallic ">Patient or Patient Representative Sends Secure Electronic Message to EP/EC During the Calendar Year</th>
                           <th class="divTableCell blueItallic ">EP/EC Replies to Secure Electronic Message from Patient or Patient Representative During the Calendar Year</th>
                           <th class="divTableCell blueItallic ">EP/EC Sends Secure Electronic Message to Patient or Patient Representative During the Calendar Year</th>
@@ -660,7 +660,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second encounter, during</li></td>
+                          <td class="divTableCell ">Second encounter</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">N/A</li></td>
                           <td class="divTableCell ">No</li></td>

--- a/exports/test_data/G1_EP_Required_Test_5.html
+++ b/exports/test_data/G1_EP_Required_Test_5.html
@@ -571,7 +571,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Seen During Reporting Period </th>
+                          <th class="divTableCell blueItallic ">Patient Seen During Reporting/Performance Period </th>
                           <th class="divTableCell blueItallic ">Patient or Patient Representative Sends Secure Electronic Message to EP/EC During the Calendar Year</th>
                           <th class="divTableCell blueItallic ">EP/EC Replies to Secure Electronic Message from Patient or Patient Representative During the Calendar Year</th>
                           <th class="divTableCell blueItallic ">EP/EC Sends Secure Electronic Message to Patient or Patient Representative During the Calendar Year</th>

--- a/exports/test_data/G1_EP_Required_Test_6.html
+++ b/exports/test_data/G1_EP_Required_Test_6.html
@@ -370,7 +370,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Seen Within or Outside Reporting/Performance Period </th>
+                          <th class="divTableCell blueItallic ">Patient Seen Within Reporting/Performance Period </th>
                           <th class="divTableCell blueItallic ">Patient Data From Non-Clinical Settings Captured During Reporting/Performance Period</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -380,7 +380,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell">0</td>
                         </tr>
@@ -390,7 +390,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell">0</td>
                         </tr>
@@ -400,7 +400,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell">0</td>
                         </tr>
@@ -410,7 +410,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -420,7 +420,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -449,7 +449,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Seen Within or Outside Reporting/Performance Period </th>
+                          <th class="divTableCell blueItallic ">Patient Seen Within Reporting/Performance Period </th>
                           <th class="divTableCell blueItallic ">Patient Data From Non-Clinical Settings Captured During Reporting/Performance Period</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -459,7 +459,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second encounter, during</li></td>
+                          <td class="divTableCell ">Second encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -469,7 +469,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second encounter, during</li></td>
+                          <td class="divTableCell ">Second encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -479,7 +479,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second encounter, during</li></td>
+                          <td class="divTableCell ">Second encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -508,7 +508,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Seen Within or Outside Reporting/Performance Period </th>
+                          <th class="divTableCell blueItallic ">Patient Seen Within Reporting/Performance Period </th>
                           <th class="divTableCell blueItallic ">Patient Data From Non-Clinical Settings Captured During Reporting/Performance Period</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -518,7 +518,7 @@
                             <div class="divSmall">4/23/1967</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -528,7 +528,7 @@
                             <div class="divSmall">7/27/1983</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -538,7 +538,7 @@
                             <div class="divSmall">9/6/1983</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First encounter, during</li></td>
+                          <td class="divTableCell ">First encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">1</td>
                         </tr>
@@ -567,7 +567,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Seen Within or Outside Reporting/Performance Period </th>
+                          <th class="divTableCell blueItallic ">Patient Seen Within Reporting/Performance Period </th>
                           <th class="divTableCell blueItallic ">Patient Data From Non-Clinical Settings Captured During Reporting/Performance Period</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -577,7 +577,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second encounter, during</li></td>
+                          <td class="divTableCell ">Second encounter</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell">0</td>
                         </tr>

--- a/exports/test_data/G1_EP_Required_Test_9.html
+++ b/exports/test_data/G1_EP_Required_Test_9.html
@@ -370,7 +370,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Transitioned, Referred, New, or Existing Patient Within Reporting/ Performance Period </th>
+                          <th class="divTableCell blueItallic ">Transitioned, Referred, New, or Existing Patient Within Reporting / Performance Period </th>
                           <th class="divTableCell blueItallic ">Medication Reconciliation During the Calendar Year</th>
                           <th class="divTableCell blueItallic ">Medication Allergy Reconciliation During the Calendar Year</th>
                           <th class="divTableCell blueItallic ">Current Problem List Reconciliation During the Calendar Year</th>
@@ -467,7 +467,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Transitioned, Referred, New, or Existing Patient Within Reporting/ Performance Period </th>
+                          <th class="divTableCell blueItallic ">Transitioned, Referred, New, or Existing Patient Within Reporting / Performance Period </th>
                           <th class="divTableCell blueItallic ">Medication Reconciliation During the Calendar Year</th>
                           <th class="divTableCell blueItallic ">Medication Allergy Reconciliation During the Calendar Year</th>
                           <th class="divTableCell blueItallic ">Current Problem List Reconciliation During the Calendar Year</th>

--- a/exports/test_data/G2_EH_General_Notes.html
+++ b/exports/test_data/G2_EH_General_Notes.html
@@ -486,6 +486,11 @@
                 <div class="divTableCell">Updated column headers in RT2a and RT2b to correctly specify View, Download, and Transmit.</div>
                 <div class="divTableCell">5/5/2021</div>
               </div>
+              <div class="divTableRow">
+                <div class="divTableCell">2.4</div>
+                <div class="divTableCell">Added Guidance to hide Automated Drug Queries for 2021 RT1 tests for Medicare. Removed references to encounters that happen outside Reporting/Performance Period for RT1, RT2, RT3, RT4, RT5, RT6, RT7, RT8, RT9, RT10, RT11, RT12 and RT15.</div>
+                <div class="divTableCell">6/25/2021</div>
+              </div>
           </div>
         </div>
     <script src="https://code.jquery.com/jquery-1.12.4.min.js"></script>

--- a/exports/test_data/G2_EH_Required_Test_1.html
+++ b/exports/test_data/G2_EH_Required_Test_1.html
@@ -364,7 +364,7 @@
             <div class="divTableCell noBorder">2: If a Health IT Module automatically transmits a prescription electronically when it is generated, it is at the discretion of the ATL not to test scenarios that assume this is not automatic.</div>
           </div>
           <div class="divTableNoteRow">
-            <div class="divTableCell noBorder">3: If a Health IT Module automatically queries for a drug formulary upon every prescription that is generated, it is at the discretion of the ATL not to test scenarios that assume this is not automatic.</div>
+            <div class="divTableCell noBorder">3: If a Health IT Module automatically queries for a drug formulary upon every prescription that is generated, it is at the discretion of the ATL not to test scenarios that assume this is not automatic. Additionally, the 2021 specification for Medicare has removed the requirement for formulary checking as part of the calculations.</div>
           </div>
           <div class="divTableNoteRow">
             <div class="divTableCell noBorder">4: If a Health IT Module can only send changes electronically, it is at the discretion of the ATL not to test scenarios that assume a change could be sent via non-electronic means.</div>
@@ -432,7 +432,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Prescriptions  (New, Changed) Written Within or Outside the Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Prescriptions  (New, Changed) Written Within the Reporting Period</th>
                           <th class="divTableCell blueItallic ">Number of Prescriptions Written (not controlled)</th>
                           <th class="divTableCell blueItallic ">Number of Controlled Prescriptions Written</th>
                           <th class="divTableCell blueItallic automatable2">Number of Prescriptions (not controlled) Generated and Transmitted Electronically</th>
@@ -553,7 +553,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Prescriptions  (New, Changed) Written Within or Outside the Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Prescriptions  (New, Changed) Written Within the Reporting Period</th>
                           <th class="divTableCell blueItallic ">Number of Prescriptions Written</th>
                           <th class="divTableCell blueItallic automatable2">Number of Prescriptions Generated and Transmitted Electronically</th>
                           <th class="divTableCell blueItallic automatable1">Prescription(s) Queried for Drug Formulary</th>
@@ -668,7 +668,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Prescriptions  (New, Changed) Written Within or Outside the Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Prescriptions  (New, Changed) Written Within the Reporting Period</th>
                           <th class="divTableCell blueItallic ">Number of Prescriptions Written (not controlled)</th>
                           <th class="divTableCell blueItallic ">Number of Controlled Prescriptions Written</th>
                           <th class="divTableCell blueItallic automatable2">Number of Prescriptions (not controlled) Generated and Transmitted Electronically</th>
@@ -772,7 +772,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Prescriptions  (New, Changed) Written Within or Outside the Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Prescriptions  (New, Changed) Written Within the Reporting Period</th>
                           <th class="divTableCell blueItallic ">Number of Prescriptions Written</th>
                           <th class="divTableCell blueItallic automatable2">Number of Prescriptions Generated and Transmitted Electronically</th>
                           <th class="divTableCell blueItallic automatable1">Prescription(s) Queried for Drug Formulary</th>
@@ -868,7 +868,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Prescriptions  (New, Changed) Written Within or Outside the Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Prescriptions  (New, Changed) Written Within the Reporting Period</th>
                           <th class="divTableCell blueItallic ">Number of Prescriptions Written (not controlled)</th>
                           <th class="divTableCell blueItallic ">Number of Controlled Prescriptions Written</th>
                           <th class="divTableCell blueItallic automatable2">Number of Prescriptions (not controlled) Generated and Transmitted Electronically</th>
@@ -972,7 +972,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Prescriptions  (New, Changed) Written Within or Outside the Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Prescriptions  (New, Changed) Written Within the Reporting Period</th>
                           <th class="divTableCell blueItallic ">Number of Prescriptions Written</th>
                           <th class="divTableCell blueItallic automatable2">Number of Prescriptions Generated and Transmitted Electronically</th>
                           <th class="divTableCell blueItallic automatable1">Prescription(s) Queried for Drug Formulary</th>

--- a/exports/test_data/G2_EH_Required_Test_1.html
+++ b/exports/test_data/G2_EH_Required_Test_1.html
@@ -364,7 +364,7 @@
             <div class="divTableCell noBorder">2: If a Health IT Module automatically transmits a prescription electronically when it is generated, it is at the discretion of the ATL not to test scenarios that assume this is not automatic.</div>
           </div>
           <div class="divTableNoteRow">
-            <div class="divTableCell noBorder">3: If a Health IT Module automatically queries for a drug formulary upon every prescription that is generated, it is at the discretion of the ATL not to test scenarios that assume this is not automatic. Additionally, the 2021 specification for Medicare has removed the requirement for formulary checking as part of the calculations.</div>
+            <div class="divTableCell noBorder">3: If a Health IT Module automatically queries for a drug formulary upon every prescription that is generated, it is at the discretion of the ATL not to test scenarios that assume this is not automatic. Additionally, the 2021 specification for Medicare has removed the requirement for formulary checking as part of the calculations (Select &#39;Hide - Automated Drug Queries&#39; to remove this step from the test data).</div>
           </div>
           <div class="divTableNoteRow">
             <div class="divTableCell noBorder">4: If a Health IT Module can only send changes electronically, it is at the discretion of the ATL not to test scenarios that assume a change could be sent via non-electronic means.</div>

--- a/exports/test_data/G2_EH_Required_Test_1.html
+++ b/exports/test_data/G2_EH_Required_Test_1.html
@@ -446,7 +446,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">New, Within</li></td>
+                          <td class="divTableCell ">New</li></td>
                           <td class="divTableCell ">2</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell automatable2">2</li></td>
@@ -463,7 +463,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">New, Within</li></td>
+                          <td class="divTableCell ">New</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell ">0</li></td>
                           <td class="divTableCell automatable2">1</li></td>
@@ -480,7 +480,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Changed, Within</li></td>
+                          <td class="divTableCell ">Changed</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell automatable2">1</li></td>
@@ -497,7 +497,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Changed, Within</li></td>
+                          <td class="divTableCell ">Changed</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell automatable2">1</li></td>
@@ -514,7 +514,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">New, Within</li></td>
+                          <td class="divTableCell ">New</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell ">2</li></td>
                           <td class="divTableCell automatable2">1</li></td>
@@ -565,7 +565,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">New, Within</li></td>
+                          <td class="divTableCell ">New</li></td>
                           <td class="divTableCell ">2</li></td>
                           <td class="divTableCell automatable2">2</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
@@ -580,7 +580,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">New, Within</li></td>
+                          <td class="divTableCell ">New</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell automatable2">1</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
@@ -595,7 +595,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Changed, Within</li></td>
+                          <td class="divTableCell ">Changed</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell automatable2">1</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
@@ -610,7 +610,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Changed, Within</li></td>
+                          <td class="divTableCell ">Changed</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell automatable2">1</li></td>
                           <td class="divTableCell automatable1">No</li></td>
@@ -625,7 +625,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">New, Within</li></td>
+                          <td class="divTableCell ">New</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell automatable2">1</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
@@ -682,7 +682,7 @@
                             <div class="divSmall">4/23/1967</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">New, Within</li></td>
+                          <td class="divTableCell ">New</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell ">0</li></td>
                           <td class="divTableCell automatable2">1</li></td>
@@ -699,7 +699,7 @@
                             <div class="divSmall">9/25/1972</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">New, Within</li></td>
+                          <td class="divTableCell ">New</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell automatable2">1</li></td>
@@ -716,7 +716,7 @@
                             <div class="divSmall">7/27/1983</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Changed, Within</li></td>
+                          <td class="divTableCell ">Changed</li></td>
                           <td class="divTableCell ">2</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell automatable2">2</li></td>
@@ -733,7 +733,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Changed, Within</li></td>
+                          <td class="divTableCell ">Changed</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell ">2</li></td>
                           <td class="divTableCell automatable2">1</li></td>
@@ -784,7 +784,7 @@
                             <div class="divSmall">4/23/1967</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">New, Within</li></td>
+                          <td class="divTableCell ">New</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell automatable2">1</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
@@ -799,7 +799,7 @@
                             <div class="divSmall">9/25/1972</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">New, Within</li></td>
+                          <td class="divTableCell ">New</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell automatable2">1</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
@@ -814,7 +814,7 @@
                             <div class="divSmall">7/27/1983</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Changed, Within</li></td>
+                          <td class="divTableCell ">Changed</li></td>
                           <td class="divTableCell ">2</li></td>
                           <td class="divTableCell automatable2">2</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
@@ -829,7 +829,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Changed, Within</li></td>
+                          <td class="divTableCell ">Changed</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell automatable2">1</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
@@ -882,7 +882,7 @@
                             <div class="divSmall">6/24/2001</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">New, Within</li></td>
+                          <td class="divTableCell ">New</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell ">0</li></td>
                           <td class="divTableCell automatable2">1</li></td>
@@ -899,7 +899,7 @@
                             <div class="divSmall">9/15/1999</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">New, Within</li></td>
+                          <td class="divTableCell ">New</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell ">0</li></td>
                           <td class="divTableCell automatable2">0</li></td>
@@ -916,7 +916,7 @@
                             <div class="divSmall">2/19/1980</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Changed, Within</li></td>
+                          <td class="divTableCell ">Changed</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell automatable2">1</li></td>
@@ -933,7 +933,7 @@
                             <div class="divSmall">11/14/2005</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Changed, Within</li></td>
+                          <td class="divTableCell ">Changed</li></td>
                           <td class="divTableCell ">2</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell automatable2">0</li></td>
@@ -984,7 +984,7 @@
                             <div class="divSmall">6/24/2001</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">New, Within</li></td>
+                          <td class="divTableCell ">New</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell automatable2">1</li></td>
                           <td class="divTableCell automatable1">No</li></td>
@@ -999,7 +999,7 @@
                             <div class="divSmall">9/15/1999</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">New, Within</li></td>
+                          <td class="divTableCell ">New</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell automatable2">0</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
@@ -1014,7 +1014,7 @@
                             <div class="divSmall">2/19/1980</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Changed, Within</li></td>
+                          <td class="divTableCell ">Changed</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell automatable2">1</li></td>
                           <td class="divTableCell automatable1">No</li></td>
@@ -1029,7 +1029,7 @@
                             <div class="divSmall">11/14/2005</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Changed, Within</li></td>
+                          <td class="divTableCell ">Changed</li></td>
                           <td class="divTableCell ">2</li></td>
                           <td class="divTableCell automatable2">0</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>

--- a/exports/test_data/G2_EH_Required_Test_10.html
+++ b/exports/test_data/G2_EH_Required_Test_10.html
@@ -364,7 +364,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Medication Orders Created Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Medication Orders Created Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Medication Orders Created</th>
                           <th class="divTableCell blueItallic ">Number of Medication Orders Recorded Using CPOE</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -454,7 +454,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Medication Orders Created Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Medication Orders Created Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Medication Orders Created</th>
                           <th class="divTableCell blueItallic ">Number of Medication Orders Recorded Using CPOE</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -529,7 +529,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Medication Orders Created Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Medication Orders Created Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Medication Orders Created</th>
                           <th class="divTableCell blueItallic ">Number of Medication Orders Recorded Using CPOE</th>
                         <th class="divTableCell blueItallic">Records Total</th>

--- a/exports/test_data/G2_EH_Required_Test_11.html
+++ b/exports/test_data/G2_EH_Required_Test_11.html
@@ -364,7 +364,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Laboratory Orders Created Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Laboratory Orders Created Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Laboratory Orders Created</th>
                           <th class="divTableCell blueItallic ">Number of Laboratory Orders Recorded Using CPOE</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -454,7 +454,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Laboratory Orders Created Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Laboratory Orders Created Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Laboratory Orders Created</th>
                           <th class="divTableCell blueItallic ">Number of Laboratory Orders Recorded Using CPOE</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -529,7 +529,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Laboratory Orders Created Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Laboratory Orders Created Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Laboratory Orders Created</th>
                           <th class="divTableCell blueItallic ">Number of Laboratory Orders Recorded Using CPOE</th>
                         <th class="divTableCell blueItallic">Records Total</th>

--- a/exports/test_data/G2_EH_Required_Test_12.html
+++ b/exports/test_data/G2_EH_Required_Test_12.html
@@ -364,7 +364,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Diagnostic Imaging Orders Created Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Diagnostic Imaging Orders Created Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Diagnostic Imaging Orders Created</th>
                           <th class="divTableCell blueItallic ">Number of Diagnostic Imaging Orders Recorded Using CPOE</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -454,7 +454,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Diagnostic Imaging Orders Created Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Diagnostic Imaging Orders Created Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Diagnostic Imaging Orders Created</th>
                           <th class="divTableCell blueItallic ">Number of Diagnostic Imaging Orders Recorded Using CPOE</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -529,7 +529,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Diagnostic Imaging Orders Created Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Diagnostic Imaging Orders Created Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Diagnostic Imaging Orders Created</th>
                           <th class="divTableCell blueItallic ">Number of Diagnostic Imaging Orders Recorded Using CPOE</th>
                         <th class="divTableCell blueItallic">Records Total</th>

--- a/exports/test_data/G2_EH_Required_Test_15.html
+++ b/exports/test_data/G2_EH_Required_Test_15.html
@@ -389,7 +389,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">3</li></td>
                           <td class="divTableCell ">3</li></td>
                           <td class="divTableCell ">3</li></td>
@@ -402,7 +402,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">2</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell ">2</li></td>
@@ -415,7 +415,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">5</li></td>
                           <td class="divTableCell ">2</li></td>
                           <td class="divTableCell ">2</li></td>
@@ -428,7 +428,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell ">1</li></td>
@@ -441,7 +441,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">2</li></td>
                           <td class="divTableCell ">0</li></td>
                           <td class="divTableCell ">0</li></td>
@@ -493,7 +493,7 @@
                             <div class="divSmall">4/23/1967</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell ">1</li></td>
@@ -506,7 +506,7 @@
                             <div class="divSmall">9/25/1972</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">2</li></td>
                           <td class="divTableCell ">2</li></td>
                           <td class="divTableCell ">2</li></td>
@@ -519,7 +519,7 @@
                             <div class="divSmall">7/27/1983</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">4</li></td>
                           <td class="divTableCell ">3</li></td>
                           <td class="divTableCell ">3</li></td>
@@ -532,7 +532,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">3</li></td>
                           <td class="divTableCell ">3</li></td>
                           <td class="divTableCell ">3</li></td>
@@ -580,7 +580,7 @@
                             <div class="divSmall">6/24/2001</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">4</li></td>
                           <td class="divTableCell ">2</li></td>
                           <td class="divTableCell ">4</li></td>
@@ -593,7 +593,7 @@
                             <div class="divSmall">9/15/1999</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">1</li></td>
                           <td class="divTableCell ">0</li></td>
                           <td class="divTableCell ">0</li></td>
@@ -606,7 +606,7 @@
                             <div class="divSmall">2/19/1980</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">2</li></td>
                           <td class="divTableCell ">0</li></td>
                           <td class="divTableCell ">1</li></td>
@@ -619,7 +619,7 @@
                             <div class="divSmall">11/14/2005</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">3</li></td>
                           <td class="divTableCell ">2</li></td>
                           <td class="divTableCell ">0</li></td>

--- a/exports/test_data/G2_EH_Required_Test_15.html
+++ b/exports/test_data/G2_EH_Required_Test_15.html
@@ -376,7 +376,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Admitted Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Patient Admitted Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Number of Electronic Summary of Care Records Received</th>
                           <th class="divTableCell blueItallic ">Number of Electronic Summary of Care Records Where Medication Reconciliation Occurred During the Performance Period</th>
                           <th class="divTableCell blueItallic ">Number of Electronic Summary of Care Records Where Medication Allergy Reconciliation Occurred During the Performance Period</th>
@@ -480,7 +480,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Admitted Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Patient Admitted Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Number of Electronic Summary of Care Records Received</th>
                           <th class="divTableCell blueItallic ">Number of Electronic Summary of Care Records Where Medication Reconciliation Occurred During the Performance Period</th>
                           <th class="divTableCell blueItallic ">Number of Electronic Summary of Care Records Where Medication Allergy Reconciliation Occurred During the Performance Period</th>
@@ -567,7 +567,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Admitted Within or Outside Reporting Period </th>
+                          <th class="divTableCell blueItallic ">Patient Admitted Within Reporting Period </th>
                           <th class="divTableCell blueItallic ">Number of Electronic Summary of Care Records Received</th>
                           <th class="divTableCell blueItallic ">Number of Electronic Summary of Care Records Where  Medication Reconciliation Occurred During the Performance Period</th>
                           <th class="divTableCell blueItallic ">Number of Electronic Summary of Care Records Where  Medication Allergy Reconciliation Occurred During the Performance Period</th>

--- a/exports/test_data/G2_EH_Required_Test_2a_.html
+++ b/exports/test_data/G2_EH_Required_Test_2a_.html
@@ -646,7 +646,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting / Performance Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient Provided Access to View, Download, and Transmit Their Health Information within 36 hours</th>
                           <th class="divTableCell blueItallic automatable1">Patient Health Information is Available to Access via API within 36 hours</th>
                         <th class="divTableCell blueItallic">Records Total</th>

--- a/exports/test_data/G2_EH_Required_Test_2a_.html
+++ b/exports/test_data/G2_EH_Required_Test_2a_.html
@@ -424,7 +424,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting / Performance Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting / Performance Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient Provided Access to View, Download, and Transmit Their Health Information within 36 hours</th>
                           <th class="divTableCell blueItallic automatable1">Patient Health Information is Available to Access via API within 36 hours</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -435,7 +435,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1 / 1</td>
@@ -447,7 +447,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1 / 1</td>
@@ -459,7 +459,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1 / 1</td>
@@ -471,7 +471,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0 / 1</td>
@@ -483,7 +483,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1 / 1</td>
@@ -514,7 +514,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting / Performance Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting / Performance Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient Provided Access to View, Download, and Transmit Their Health Information within 36 hours</th>
                           <th class="divTableCell blueItallic automatable1">Patient Health Information is Available to Access via API within 36 hours</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -525,7 +525,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">-1 / 0</td>
@@ -537,7 +537,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">-1 / 0</td>
@@ -549,7 +549,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">-1 / 0</td>
@@ -580,7 +580,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting / Performance Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting / Performance Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient Provided Access to View, Download, and Transmit Their Health Information within 36 hours</th>
                           <th class="divTableCell blueItallic automatable1">Patient Health Information is Available to Access via API within 36 hours</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -591,7 +591,7 @@
                             <div class="divSmall">4/23/1967</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1 / 1</td>
@@ -603,7 +603,7 @@
                             <div class="divSmall">9/25/1972</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1 / 1</td>
@@ -615,7 +615,7 @@
                             <div class="divSmall">7/27/1983</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1 / 1</td>
@@ -646,7 +646,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient Provided Access to View, Download, and Transmit Their Health Information within 36 hours</th>
                           <th class="divTableCell blueItallic automatable1">Patient Health Information is Available to Access via API within 36 hours</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -657,7 +657,7 @@
                             <div class="divSmall">6/24/2001</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0 / 1</td>
@@ -669,7 +669,7 @@
                             <div class="divSmall">9/15/1999</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0 / 1</td>
@@ -681,7 +681,7 @@
                             <div class="divSmall">2/19/1980</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0 / 1</td>
@@ -693,7 +693,7 @@
                             <div class="divSmall">11/14/2005</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0 / 1</td>
@@ -724,7 +724,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting / Performance Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting / Performance Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient Provided Access to View, Download, and Transmit Their Health Information within 36 hours</th>
                           <th class="divTableCell blueItallic ">Patient Health Information is Available to Access via API within 36 hours</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -735,7 +735,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0 / 0</td>

--- a/exports/test_data/G2_EH_Required_Test_2b_.html
+++ b/exports/test_data/G2_EH_Required_Test_2b_.html
@@ -424,7 +424,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting / Performance Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting / Performance Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient Provided Access to View, Download, and Transmit Their Health Information within 36 hours</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -434,7 +434,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1 / 1</td>
                                     <td class="divTableCell noWrap automated1_result">1 / 1</td>
@@ -445,7 +445,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1 / 1</td>
                                     <td class="divTableCell noWrap automated1_result">1 / 1</td>
@@ -456,7 +456,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1 / 1</td>
                                     <td class="divTableCell noWrap automated1_result">1 / 1</td>
@@ -467,7 +467,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0 / 1</td>
                                     <td class="divTableCell noWrap automated1_result">1 / 1</td>
@@ -478,7 +478,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1 / 1</td>
                                     <td class="divTableCell noWrap automated1_result">1 / 1</td>
@@ -507,7 +507,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting / Performance Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting / Performance Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient Provided Access to View, Download, and Transmit Their Health Information within 36 hours</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -517,7 +517,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">-1 / 0</td>
                                     <td class="divTableCell noWrap automated1_result">0 / 0</td>
@@ -528,7 +528,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">-1 / 0</td>
                                     <td class="divTableCell noWrap automated1_result">0 / 0</td>
@@ -539,7 +539,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">-1 / 0</td>
                                     <td class="divTableCell noWrap automated1_result">0 / 0</td>
@@ -568,7 +568,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting / Performance Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting / Performance Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient Provided Access to View, Download, and Transmit Their Health Information within 36 hours</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -578,7 +578,7 @@
                             <div class="divSmall">4/23/1967</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1 / 1</td>
                                     <td class="divTableCell noWrap automated1_result">1 / 1</td>
@@ -589,7 +589,7 @@
                             <div class="divSmall">9/25/1972</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1 / 1</td>
                                     <td class="divTableCell noWrap automated1_result">1 / 1</td>
@@ -600,7 +600,7 @@
                             <div class="divSmall">7/27/1983</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1 / 1</td>
                                     <td class="divTableCell noWrap automated1_result">1 / 1</td>
@@ -629,7 +629,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient Provided Access to View, Download, and Transmit Their Health Information within 36 hours</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -639,7 +639,7 @@
                             <div class="divSmall">6/24/2001</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0 / 1</td>
                                     <td class="divTableCell noWrap automated1_result">1 / 1</td>
@@ -650,7 +650,7 @@
                             <div class="divSmall">9/15/1999</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0 / 1</td>
                                     <td class="divTableCell noWrap automated1_result">1 / 1</td>
@@ -661,7 +661,7 @@
                             <div class="divSmall">2/19/1980</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0 / 1</td>
                                     <td class="divTableCell noWrap automated1_result">1 / 1</td>
@@ -672,7 +672,7 @@
                             <div class="divSmall">11/14/2005</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0 / 1</td>
                                     <td class="divTableCell noWrap automated1_result">1 / 1</td>
@@ -701,7 +701,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting / Performance Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting / Performance Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient Provided Access to View, Download, and Transmit Their Health Information within 36 hours</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -711,7 +711,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0 / 0</td>
                                     <td class="divTableCell noWrap automated1_result">0 / 0</td>

--- a/exports/test_data/G2_EH_Required_Test_2b_.html
+++ b/exports/test_data/G2_EH_Required_Test_2b_.html
@@ -629,7 +629,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting / Performance Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient Provided Access to View, Download, and Transmit Their Health Information within 36 hours</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>

--- a/exports/test_data/G2_EH_Required_Test_2c_.html
+++ b/exports/test_data/G2_EH_Required_Test_2c_.html
@@ -424,7 +424,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting / Performance Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting / Performance Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient Health Information is Available to Access via API within 36 hours</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -434,7 +434,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1 / 1</td>
                                     <td class="divTableCell noWrap automated1_result">1 / 1</td>
@@ -445,7 +445,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1 / 1</td>
                                     <td class="divTableCell noWrap automated1_result">1 / 1</td>
@@ -456,7 +456,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1 / 1</td>
                                     <td class="divTableCell noWrap automated1_result">1 / 1</td>
@@ -467,7 +467,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0 / 1</td>
                                     <td class="divTableCell noWrap automated1_result">1 / 1</td>
@@ -478,7 +478,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1 / 1</td>
                                     <td class="divTableCell noWrap automated1_result">1 / 1</td>
@@ -507,7 +507,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting / Performance Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting / Performance Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient Health Information is Available to Access via API within 36 hours</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -517,7 +517,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">-1 / 0</td>
                                     <td class="divTableCell noWrap automated1_result">0 / 0</td>
@@ -528,7 +528,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">-1 / 0</td>
                                     <td class="divTableCell noWrap automated1_result">0 / 0</td>
@@ -539,7 +539,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">-1 / 0</td>
                                     <td class="divTableCell noWrap automated1_result">0 / 0</td>
@@ -568,7 +568,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting / Performance Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting / Performance Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient Health Information is Available to Access via API within 36 hours</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -578,7 +578,7 @@
                             <div class="divSmall">4/23/1967</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1 / 1</td>
                                     <td class="divTableCell noWrap automated1_result">1 / 1</td>
@@ -589,7 +589,7 @@
                             <div class="divSmall">9/25/1972</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1 / 1</td>
                                     <td class="divTableCell noWrap automated1_result">1 / 1</td>
@@ -600,7 +600,7 @@
                             <div class="divSmall">7/27/1983</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1 / 1</td>
                                     <td class="divTableCell noWrap automated1_result">1 / 1</td>
@@ -629,7 +629,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient Health Information is Available to Access via API within 36 hours</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -639,7 +639,7 @@
                             <div class="divSmall">6/24/2001</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0 / 1</td>
                                     <td class="divTableCell noWrap automated1_result">1 / 1</td>
@@ -650,7 +650,7 @@
                             <div class="divSmall">9/15/1999</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0 / 1</td>
                                     <td class="divTableCell noWrap automated1_result">1 / 1</td>
@@ -661,7 +661,7 @@
                             <div class="divSmall">2/19/1980</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0 / 1</td>
                                     <td class="divTableCell noWrap automated1_result">1 / 1</td>
@@ -672,7 +672,7 @@
                             <div class="divSmall">11/14/2005</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0 / 1</td>
                                     <td class="divTableCell noWrap automated1_result">1 / 1</td>
@@ -701,7 +701,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting / Performance Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting / Performance Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient Health Information is Available to Access via API within 36 hours</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -711,7 +711,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0 / 0</td>
                                     <td class="divTableCell noWrap automated1_result">0 / 0</td>

--- a/exports/test_data/G2_EH_Required_Test_2c_.html
+++ b/exports/test_data/G2_EH_Required_Test_2c_.html
@@ -629,7 +629,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting / Performance Period</th>
                           <th class="divTableCell blueItallic automatable1">Patient Health Information is Available to Access via API within 36 hours</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>

--- a/exports/test_data/G2_EH_Required_Test_3.html
+++ b/exports/test_data/G2_EH_Required_Test_3.html
@@ -385,7 +385,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">CEHRT Identifies Patient-Specific Education Resources  During  Calendar Year</th>
                           <th class="divTableCell blueItallic automatable1">EH Provides Electronic Access to Patient-Specific Educational Resources Identified by CEHRT During Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -396,7 +396,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Identified</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0 / 1</td>
@@ -408,7 +408,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Not identified</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0 / 1</td>
@@ -420,7 +420,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Not identified</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0 / 1</td>
@@ -432,7 +432,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Not identified</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0 / 1</td>
@@ -444,7 +444,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Identified</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1 / 1</td>
@@ -475,7 +475,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">CEHRT Identifies Patient-Specific Education Resources  During  Calendar Year</th>
                           <th class="divTableCell blueItallic automatable1">EH Provides Electronic Access to Patient-Specific Educational Resources Identified by CEHRT During Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -486,7 +486,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Identified</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1 / 0</td>
@@ -498,7 +498,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Identified</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1 / 0</td>
@@ -510,7 +510,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Identified</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1 / 0</td>
@@ -541,7 +541,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">CEHRT Identifies Patient-Specific Education Resources  During  Calendar Year</th>
                           <th class="divTableCell blueItallic automatable1">EH Provides Electronic Access to Patient-Specific Educational Resources Identified by CEHRT During Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -552,7 +552,7 @@
                             <div class="divSmall">4/23/1967</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Identified</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1 / 1</td>
@@ -564,7 +564,7 @@
                             <div class="divSmall">9/25/1972</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Identified</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1 / 1</td>
@@ -576,7 +576,7 @@
                             <div class="divSmall">7/27/1983</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Identified</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">1 / 1</td>
@@ -607,7 +607,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">CEHRT Identifies Patient-Specific Education Resources  During  Calendar Year</th>
                           <th class="divTableCell blueItallic automatable1">EH Provides Electronic Access to Patient-Specific Educational Resources Identified by CEHRT During Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -618,7 +618,7 @@
                             <div class="divSmall">6/24/2001</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Identified</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0 / 1</td>
@@ -630,7 +630,7 @@
                             <div class="divSmall">9/15/1999</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Not identified</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0 / 1</td>
@@ -642,7 +642,7 @@
                             <div class="divSmall">2/19/1980</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Not identified</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0 / 1</td>
@@ -654,7 +654,7 @@
                             <div class="divSmall">11/14/2005</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Not identified</li></td>
                           <td class="divTableCell automatable1">No</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0 / 1</td>
@@ -685,7 +685,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">CEHRT Identifies Patient-Specific Education Resources  During  Calendar Year</th>
                           <th class="divTableCell blueItallic automatable1">EH Provides Electronic Access to Patient-Specific Educational Resources Identified by CEHRT During Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -696,7 +696,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Identified</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
                                 <td class="divTableCell noWrap not_automated_result">0 / 0</td>

--- a/exports/test_data/G2_EH_Required_Test_4a_.html
+++ b/exports/test_data/G2_EH_Required_Test_4a_.html
@@ -379,7 +379,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">Patient or Authorized Representative Viewed (Downloaded or Transmitted) their Information During the Calendar Year</th>
                           <th class="divTableCell blueItallic ">Patient Accessed Health Information Through API During the Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -390,7 +390,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell noWrap">0 / 1</td>
@@ -401,7 +401,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell noWrap">0 / 1</td>
@@ -412,7 +412,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell noWrap">0 / 1</td>
@@ -423,7 +423,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell noWrap">1 / 1</td>
@@ -434,7 +434,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell noWrap">1 / 1</td>
@@ -465,7 +465,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">Patient or Authorized Representative Viewed (Downloaded or Transmitted) their Information During the Calendar Year</th>
                           <th class="divTableCell blueItallic ">Patient Accessed Health Information Through API During the Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -476,7 +476,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell noWrap">1 / 0</td>
@@ -487,7 +487,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell noWrap">1 / 0</td>
@@ -498,7 +498,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell noWrap">1 / 0</td>
@@ -529,7 +529,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">Patient or Authorized Representative Viewed (Downloaded or Transmitted) their Information During the Calendar Year</th>
                           <th class="divTableCell blueItallic ">Patient Accessed Health Information Through API During the Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -540,7 +540,7 @@
                             <div class="divSmall">4/23/1967</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell noWrap">1 / 1</td>
@@ -551,7 +551,7 @@
                             <div class="divSmall">9/25/1972</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell noWrap">1 / 1</td>
@@ -562,7 +562,7 @@
                             <div class="divSmall">7/27/1983</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell noWrap">1 / 1</td>
@@ -593,7 +593,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">Patient or Authorized Representative Viewed (Downloaded or Transmitted) their Information During the Calendar Year</th>
                           <th class="divTableCell blueItallic ">Patient Accessed Health Information Through API During the Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -604,7 +604,7 @@
                             <div class="divSmall">6/24/2001</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell noWrap">0 / 1</td>
@@ -615,7 +615,7 @@
                             <div class="divSmall">9/15/1999</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell noWrap">0 / 1</td>
@@ -626,7 +626,7 @@
                             <div class="divSmall">2/19/1980</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell noWrap">0 / 1</td>
@@ -637,7 +637,7 @@
                             <div class="divSmall">11/14/2005</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell noWrap">0 / 1</td>
@@ -668,7 +668,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">Patient or Authorized Representative Viewed (Downloaded or Transmitted) their Information During the Calendar Year</th>
                           <th class="divTableCell blueItallic ">Patient Accessed Health Information Through API During the Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -679,7 +679,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell noWrap">0 / 0</td>

--- a/exports/test_data/G2_EH_Required_Test_4b_.html
+++ b/exports/test_data/G2_EH_Required_Test_4b_.html
@@ -379,7 +379,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">Patient or Authorized Representative Viewed (Downloaded or Transmitted) their Information During the Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -389,7 +389,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell noWrap">0 / 1</td>
                         </tr>
@@ -399,7 +399,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell noWrap">0 / 1</td>
                         </tr>
@@ -409,7 +409,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell noWrap">0 / 1</td>
                         </tr>
@@ -419,7 +419,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell noWrap">1 / 1</td>
                         </tr>
@@ -429,7 +429,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell noWrap">1 / 1</td>
                         </tr>
@@ -458,7 +458,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">Patient or Authorized Representative Viewed (Downloaded or Transmitted) their Information During the Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -468,7 +468,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell noWrap">1 / 0</td>
                         </tr>
@@ -478,7 +478,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell noWrap">1 / 0</td>
                         </tr>
@@ -488,7 +488,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell noWrap">1 / 0</td>
                         </tr>
@@ -517,7 +517,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">Patient or Authorized Representative Viewed (Downloaded or Transmitted) their Information During the Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -527,7 +527,7 @@
                             <div class="divSmall">4/23/1967</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell noWrap">1 / 1</td>
                         </tr>
@@ -537,7 +537,7 @@
                             <div class="divSmall">9/25/1972</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell noWrap">1 / 1</td>
                         </tr>
@@ -547,7 +547,7 @@
                             <div class="divSmall">7/27/1983</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell noWrap">1 / 1</td>
                         </tr>
@@ -576,7 +576,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">Patient or Authorized Representative Viewed (Downloaded or Transmitted) their Information During the Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -586,7 +586,7 @@
                             <div class="divSmall">6/24/2001</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell noWrap">0 / 1</td>
                         </tr>
@@ -596,7 +596,7 @@
                             <div class="divSmall">9/15/1999</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell noWrap">0 / 1</td>
                         </tr>
@@ -606,7 +606,7 @@
                             <div class="divSmall">2/19/1980</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell noWrap">0 / 1</td>
                         </tr>
@@ -616,7 +616,7 @@
                             <div class="divSmall">11/14/2005</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell noWrap">0 / 1</td>
                         </tr>
@@ -645,7 +645,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">Patient or Authorized Representative Viewed (Downloaded or Transmitted) their Information During the Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -655,7 +655,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell noWrap">0 / 0</td>
                         </tr>

--- a/exports/test_data/G2_EH_Required_Test_4c_.html
+++ b/exports/test_data/G2_EH_Required_Test_4c_.html
@@ -379,7 +379,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">Patient Accessed Health Information Through API During the Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -389,7 +389,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell noWrap">0 / 1</td>
                         </tr>
@@ -399,7 +399,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell noWrap">0 / 1</td>
                         </tr>
@@ -409,7 +409,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell noWrap">0 / 1</td>
                         </tr>
@@ -419,7 +419,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell noWrap">1 / 1</td>
                         </tr>
@@ -429,7 +429,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell noWrap">1 / 1</td>
                         </tr>
@@ -458,7 +458,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">Patient Accessed Health Information Through API During the Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -468,7 +468,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell noWrap">1 / 0</td>
                         </tr>
@@ -478,7 +478,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell noWrap">1 / 0</td>
                         </tr>
@@ -488,7 +488,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell noWrap">1 / 0</td>
                         </tr>
@@ -517,7 +517,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">Patient Accessed Health Information Through API During the Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -527,7 +527,7 @@
                             <div class="divSmall">4/23/1967</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell noWrap">1 / 1</td>
                         </tr>
@@ -537,7 +537,7 @@
                             <div class="divSmall">9/25/1972</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell noWrap">1 / 1</td>
                         </tr>
@@ -547,7 +547,7 @@
                             <div class="divSmall">7/27/1983</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell noWrap">1 / 1</td>
                         </tr>
@@ -576,7 +576,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">Patient Accessed Health Information Through API During the Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -586,7 +586,7 @@
                             <div class="divSmall">6/24/2001</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell noWrap">0 / 1</td>
                         </tr>
@@ -596,7 +596,7 @@
                             <div class="divSmall">9/15/1999</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell noWrap">0 / 1</td>
                         </tr>
@@ -606,7 +606,7 @@
                             <div class="divSmall">2/19/1980</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell noWrap">0 / 1</td>
                         </tr>
@@ -616,7 +616,7 @@
                             <div class="divSmall">11/14/2005</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell noWrap">0 / 1</td>
                         </tr>
@@ -645,7 +645,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">Patient Accessed Health Information Through API During the Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -655,7 +655,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell noWrap">0 / 0</td>
                         </tr>

--- a/exports/test_data/G2_EH_Required_Test_5.html
+++ b/exports/test_data/G2_EH_Required_Test_5.html
@@ -394,7 +394,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">Patient or Patient Representative Sends Secure Electronic Message to EH During Calendar Year</th>
                           <th class="divTableCell blueItallic ">EH Replies to Secure Electronic Message from Patient or Patient Representative During Calendar Year</th>
                           <th class="divTableCell blueItallic ">EH Sends Secure Electronic Message to Patient or Patient Representative During Calendar Year</th>
@@ -407,7 +407,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">No</li></td>
@@ -421,7 +421,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">N/A</li></td>
                           <td class="divTableCell ">No</li></td>
@@ -435,7 +435,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">No</li></td>
@@ -449,7 +449,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
@@ -463,7 +463,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">N/A</li></td>
                           <td class="divTableCell ">Yes</li></td>
@@ -498,7 +498,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">Patient or Patient Representative Sends Secure Electronic Message to EH During Calendar Year</th>
                           <th class="divTableCell blueItallic ">EH Replies to Secure Electronic Message from Patient or Patient Representative During Calendar Year</th>
                           <th class="divTableCell blueItallic ">EH Sends Secure Electronic Message to Patient or Patient Representative During Calendar Year</th>
@@ -511,7 +511,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">No</li></td>
@@ -525,7 +525,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">N/A</li></td>
                           <td class="divTableCell ">Yes</li></td>
@@ -539,7 +539,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">N/A</li></td>
                           <td class="divTableCell ">No</li></td>
@@ -574,7 +574,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">Patient or Patient Representative Sends Secure Electronic Message to EH During Calendar Year</th>
                           <th class="divTableCell blueItallic ">EH Replies to Secure Electronic Message from Patient or Patient Representative During Calendar Year</th>
                           <th class="divTableCell blueItallic ">EH Sends Secure Electronic Message to Patient or Patient Representative During Calendar Year</th>
@@ -587,7 +587,7 @@
                             <div class="divSmall">4/23/1967</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
@@ -601,7 +601,7 @@
                             <div class="divSmall">9/25/1972</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">Yes</li></td>
@@ -615,7 +615,7 @@
                             <div class="divSmall">7/27/1983</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">N/A</li></td>
                           <td class="divTableCell ">Yes</li></td>
@@ -650,7 +650,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">Patient or Patient Representative Sends Secure Electronic Message to EH During Calendar Year</th>
                           <th class="divTableCell blueItallic ">EH Replies to Secure Electronic Message from Patient or Patient Representative During Calendar Year</th>
                           <th class="divTableCell blueItallic ">EH Sends Secure Electronic Message to Patient or Patient Representative During Calendar Year</th>
@@ -663,7 +663,7 @@
                             <div class="divSmall">6/24/2001</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">N/A</li></td>
                           <td class="divTableCell ">No</li></td>
@@ -677,7 +677,7 @@
                             <div class="divSmall">9/15/1999</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">No</li></td>
@@ -691,7 +691,7 @@
                             <div class="divSmall">2/19/1980</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">N/A</li></td>
                           <td class="divTableCell ">No</li></td>
@@ -705,7 +705,7 @@
                             <div class="divSmall">11/14/2005</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">N/A</li></td>
                           <td class="divTableCell ">No</li></td>
@@ -740,7 +740,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged During or Outside of Reporting  Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged During Reporting Period</th>
                           <th class="divTableCell blueItallic ">Patient or Patient Representative Sends Secure Electronic Message to EH During Calendar Year</th>
                           <th class="divTableCell blueItallic ">EH Replies to Secure Electronic Message from Patient or Patient Representative During Calendar Year</th>
                           <th class="divTableCell blueItallic ">EH Sends Secure Electronic Message to Patient or Patient Representative During Calendar Year</th>
@@ -753,7 +753,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">No</li></td>

--- a/exports/test_data/G2_EH_Required_Test_6.html
+++ b/exports/test_data/G2_EH_Required_Test_6.html
@@ -373,7 +373,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged Within or Outside ReportingPeriod </th>
+                          <th class="divTableCell blueItallic ">Patient Discharged Within Reporting Period </th>
                           <th class="divTableCell blueItallic ">Patient Data From Non-Clinical Settings Captured During Reporting Period</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -383,7 +383,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell noWrap">0 / 1</td>
                         </tr>
@@ -393,7 +393,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell noWrap">0 / 1</td>
                         </tr>
@@ -403,7 +403,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell noWrap">0 / 1</td>
                         </tr>
@@ -413,7 +413,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell noWrap">1 / 1</td>
                         </tr>
@@ -423,7 +423,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell noWrap">1 / 1</td>
                         </tr>
@@ -452,7 +452,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged Within or Outside ReportingPeriod </th>
+                          <th class="divTableCell blueItallic ">Patient Discharged Within Reporting Period </th>
                           <th class="divTableCell blueItallic ">Patient Data From Non-Clinical Settings Captured During Reporting Period</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -462,7 +462,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell noWrap">1 / 0</td>
                         </tr>
@@ -472,7 +472,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell noWrap">1 / 0</td>
                         </tr>
@@ -482,7 +482,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell noWrap">1 / 0</td>
                         </tr>
@@ -511,7 +511,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged Within or Outside ReportingPeriod </th>
+                          <th class="divTableCell blueItallic ">Patient Discharged Within Reporting Period </th>
                           <th class="divTableCell blueItallic ">Patient Data From Non-Clinical Settings Captured During Reporting Period</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -521,7 +521,7 @@
                             <div class="divSmall">4/23/1967</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell noWrap">1 / 1</td>
                         </tr>
@@ -531,7 +531,7 @@
                             <div class="divSmall">9/25/1972</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell noWrap">1 / 1</td>
                         </tr>
@@ -541,7 +541,7 @@
                             <div class="divSmall">7/27/1983</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell noWrap">1 / 1</td>
                         </tr>
@@ -570,7 +570,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Patient Discharged Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Patient Data From Non-Clinical Settings Captured During Reporting Period</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -580,7 +580,7 @@
                             <div class="divSmall">6/24/2001</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell noWrap">0 / 1</td>
                         </tr>
@@ -590,7 +590,7 @@
                             <div class="divSmall">9/15/1999</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell noWrap">0 / 1</td>
                         </tr>
@@ -600,7 +600,7 @@
                             <div class="divSmall">2/19/1980</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell noWrap">0 / 1</td>
                         </tr>
@@ -610,7 +610,7 @@
                             <div class="divSmall">11/14/2005</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">First discharge, during</li></td>
+                          <td class="divTableCell ">First discharge</li></td>
                           <td class="divTableCell ">No</li></td>
                                 <td class="divTableCell noWrap">0 / 1</td>
                         </tr>
@@ -639,7 +639,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Discharged Within or Outside ReportingPeriod </th>
+                          <th class="divTableCell blueItallic ">Patient Discharged Within Reporting Period </th>
                           <th class="divTableCell blueItallic ">Patient Data From Non-Clinical Settings Captured During Reporting Period</th>
                         <th class="divTableCell blueItallic">Records Total</th>
                       </tr>
@@ -649,7 +649,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Second discharge, during</li></td>
+                          <td class="divTableCell ">Second discharge</li></td>
                           <td class="divTableCell ">Yes</li></td>
                                 <td class="divTableCell noWrap">0 / 0</td>
                         </tr>

--- a/exports/test_data/G2_EH_Required_Test_7.html
+++ b/exports/test_data/G2_EH_Required_Test_7.html
@@ -397,7 +397,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Transition of Care or Referral Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Transition of Care or Referral Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Summary of Care Record (including all CMS required information or indication of none) Created and Transmitted / Exchanged Electronically During Calendar Year</th>
                           <th class="divTableCell blueItallic ">Receipt of Summary of Care Record Confirmed During Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -487,7 +487,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Transition of Care or Referral Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Transition of Care or Referral Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Summary of Care Record (including all CMS required information or indication of none) Created and Transmitted / Exchanged Electronically During Calendar Year</th>
                           <th class="divTableCell blueItallic ">Receipt of Summary of Care Record Confirmed During Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -562,7 +562,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Transition of Care or Referral Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Transition of Care or Referral Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Summary of Care Record (including all CMS required information or indication of none) Created and Transmitted / Exchanged Electronically During Calendar Year</th>
                           <th class="divTableCell blueItallic ">Receipt of Summary of Care Record Confirmed During Calendar Year</th>
                         <th class="divTableCell blueItallic">Records Total</th>

--- a/exports/test_data/G2_EH_Required_Test_8.html
+++ b/exports/test_data/G2_EH_Required_Test_8.html
@@ -400,7 +400,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">Available</li></td>
                           <td class="divTableCell ">Not Received</li></td>
                           <td class="divTableCell automatable1">Not Incorporated</li></td>
@@ -413,7 +413,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">Unavailable</li></td>
                           <td class="divTableCell ">N/A</li></td>
                           <td class="divTableCell automatable1">N/A</li></td>
@@ -426,7 +426,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">Available</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell automatable1">Not Incorporated</li></td>
@@ -439,7 +439,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">Available</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
@@ -452,7 +452,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">Available</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
@@ -501,7 +501,7 @@
                             <div class="divSmall">4/23/1967</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">Available</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
@@ -514,7 +514,7 @@
                             <div class="divSmall">9/25/1972</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">Available</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
@@ -527,7 +527,7 @@
                             <div class="divSmall">7/27/1983</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">Available</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
@@ -540,7 +540,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">Available</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell automatable1">Yes</li></td>
@@ -585,7 +585,7 @@
                             <div class="divSmall">6/24/2001</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">Available</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell automatable1">No</li></td>
@@ -598,7 +598,7 @@
                             <div class="divSmall">9/15/1999</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">Available</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell automatable1">No</li></td>
@@ -611,7 +611,7 @@
                             <div class="divSmall">2/19/1980</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">Available</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell automatable1">No</li></td>
@@ -624,7 +624,7 @@
                             <div class="divSmall">11/14/2005</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">Available</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell automatable1">No</li></td>

--- a/exports/test_data/G2_EH_Required_Test_8.html
+++ b/exports/test_data/G2_EH_Required_Test_8.html
@@ -388,7 +388,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Admitted Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Patient Admitted Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Summary of Care Record Requested and Available or Unavailable During Calendar Year</th>
                           <th class="divTableCell blueItallic ">Summary of Care Record Received through Request or Retrieval During Calendar Year</th>
                           <th class="divTableCell blueItallic automatable1">Summary of Care Record Incorporated During Calendar Year</th>
@@ -489,7 +489,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Admitted Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Patient Admitted Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Summary of Care Record Requested and Available or Unavailable During Calendar Year</th>
                           <th class="divTableCell blueItallic ">Summary of Care Record Received through Request or Retrieval During Calendar Year</th>
                           <th class="divTableCell blueItallic automatable1">Summary of Care Record Incorporated During Calendar Year</th>
@@ -573,7 +573,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Admitted Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Patient Admitted Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Summary of Care Record Requested and Available or Unavailable During Calendar Year</th>
                           <th class="divTableCell blueItallic ">Summary of Care Record Received through Request or Retrieval During Calendar Year</th>
                           <th class="divTableCell blueItallic automatable1">Summary of Care Record Incorporated During Calendar Year</th>

--- a/exports/test_data/G2_EH_Required_Test_9.html
+++ b/exports/test_data/G2_EH_Required_Test_9.html
@@ -370,7 +370,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Admitted Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Patient Admitted Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Medication Reconciliation Performed During the Calendar Year</th>
                           <th class="divTableCell blueItallic ">Medication Allergy Reconciliation Performed During the Calendar Year</th>
                           <th class="divTableCell blueItallic ">Current Problem List Reconciliation Performed During the Calendar Year</th>
@@ -467,7 +467,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Admitted Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Patient Admitted Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Medication Reconciliation Performed During the Calendar Year</th>
                           <th class="divTableCell blueItallic ">Medication Allergy Reconciliation Performed During the Calendar Year</th>
                           <th class="divTableCell blueItallic ">Current Problem List Reconciliation Performed During the Calendar Year</th>
@@ -548,7 +548,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Patient Admitted Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Patient Admitted Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Medication Reconciliation Performed During the Calendar Year</th>
                           <th class="divTableCell blueItallic ">Medication Allergy Reconciliation Performed During the Calendar Year</th>
                           <th class="divTableCell blueItallic ">Current Problem List Reconciliation Performed During the Calendar Year</th>

--- a/exports/test_data/G2_EH_Required_Test_9.html
+++ b/exports/test_data/G2_EH_Required_Test_9.html
@@ -382,7 +382,7 @@
                             <div class="divSmall">5/2/2000</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
@@ -394,7 +394,7 @@
                             <div class="divSmall">4/13/1963</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">No</li></td>
@@ -406,7 +406,7 @@
                             <div class="divSmall">10/18/1994</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">No</li></td>
@@ -418,7 +418,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">Yes</li></td>
@@ -430,7 +430,7 @@
                             <div class="divSmall">5/18/1968</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
@@ -479,7 +479,7 @@
                             <div class="divSmall">4/23/1967</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
@@ -491,7 +491,7 @@
                             <div class="divSmall">9/25/1972</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
@@ -503,7 +503,7 @@
                             <div class="divSmall">7/27/1983</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
@@ -515,7 +515,7 @@
                             <div class="divSmall">4/16/1982</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">Yes</li></td>
@@ -560,7 +560,7 @@
                             <div class="divSmall">6/24/2001</div>
                             <div class="divSmall">Sex: F</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">Yes</li></td>
                           <td class="divTableCell ">No</li></td>
@@ -572,7 +572,7 @@
                             <div class="divSmall">9/15/1999</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">Yes</li></td>
@@ -584,7 +584,7 @@
                             <div class="divSmall">2/19/1980</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">No</li></td>
@@ -596,7 +596,7 @@
                             <div class="divSmall">11/14/2005</div>
                             <div class="divSmall">Sex: M</div>
                           </td>
-                          <td class="divTableCell ">Admitted (EH/CAH), Within</li></td>
+                          <td class="divTableCell ">Admitted (EH/CAH)</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">No</li></td>
                           <td class="divTableCell ">No</li></td>

--- a/exports/test_data/G2_EP_General_Notes.html
+++ b/exports/test_data/G2_EP_General_Notes.html
@@ -510,6 +510,11 @@
                 <div class="divTableCell">Removed column in RT2b for Available to Access via API. Updated calculations for RT5.</div>
                 <div class="divTableCell">5/5/2021</div>
               </div>
+              <div class="divTableRow">
+                <div class="divTableCell">2.4</div>
+                <div class="divTableCell">Added Guidance to hide Automated Drug Queries for 2021 RT1 tests for MIPS. Removed references to encounters that happen outside Reporting/Performance Period for RT1, RT2, RT3, RT4, RT5, RT6, RT7, RT8, RT9, RT10, RT11, RT12 and RT15.</div>
+                <div class="divTableCell">6/25/2021</div>
+              </div>
           </div>
         </div>
     <script src="https://code.jquery.com/jquery-1.12.4.min.js"></script>

--- a/exports/test_data/G2_EP_Required_Test_1.html
+++ b/exports/test_data/G2_EP_Required_Test_1.html
@@ -364,7 +364,7 @@
             <div class="divTableCell noBorder">2: If a Health IT Module automatically transmits a prescription electronically when it is generated, it is at the discretion of the ONC-ATL not to test scenarios that assume this is not automatic.</div>
           </div>
           <div class="divTableNoteRow">
-            <div class="divTableCell noBorder">3: If a Health IT Module automatically queries for a drug formulary upon every prescription that is generated, it is at the discretion of the ONC-ATL not to test scenarios that assume this is not automatic.</div>
+            <div class="divTableCell noBorder">3: If a Health IT Module automatically queries for a drug formulary upon every prescription that is generated, it is at the discretion of the ONC-ATL not to test scenarios that assume this is not automatic. Additionally, the 2021 specification for MIPS has removed the requirement for formulary checking as part of the calculations.</div>
           </div>
           <div class="divTableNoteRow">
             <div class="divTableCell noBorder">4: If a Health IT Module can only send changes electronically, it is at the discretion of the ONC-ATL not to test scenarios that assume a change could be sent via non-electronic means.  </div>

--- a/exports/test_data/G2_EP_Required_Test_1.html
+++ b/exports/test_data/G2_EP_Required_Test_1.html
@@ -364,7 +364,7 @@
             <div class="divTableCell noBorder">2: If a Health IT Module automatically transmits a prescription electronically when it is generated, it is at the discretion of the ONC-ATL not to test scenarios that assume this is not automatic.</div>
           </div>
           <div class="divTableNoteRow">
-            <div class="divTableCell noBorder">3: If a Health IT Module automatically queries for a drug formulary upon every prescription that is generated, it is at the discretion of the ONC-ATL not to test scenarios that assume this is not automatic. Additionally, the 2021 specification for MIPS has removed the requirement for formulary checking as part of the calculations.</div>
+            <div class="divTableCell noBorder">3: If a Health IT Module automatically queries for a drug formulary upon every prescription that is generated, it is at the discretion of the ONC-ATL not to test scenarios that assume this is not automatic. Additionally, the 2021 specification for MIPS has removed the requirement for formulary checking as part of the calculations (Select &#39;Hide - Automated Drug Queries&#39; to remove this step from the test data).</div>
           </div>
           <div class="divTableNoteRow">
             <div class="divTableCell noBorder">4: If a Health IT Module can only send changes electronically, it is at the discretion of the ONC-ATL not to test scenarios that assume a change could be sent via non-electronic means.  </div>

--- a/exports/test_data/G2_EP_Required_Test_1.html
+++ b/exports/test_data/G2_EP_Required_Test_1.html
@@ -438,8 +438,8 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Number of Prescriptions Written during reporting/ performance period (not controlled)</th>
-                          <th class="divTableCell blueItallic divSmall ">Number of Controlled Prescriptions Written during reporting/  performance period</th>
+                          <th class="divTableCell blueItallic divSmall ">Number of Prescriptions Written During Reporting / Performance Period (not controlled)</th>
+                          <th class="divTableCell blueItallic divSmall ">Number of Controlled Prescriptions Written During Reporting / Performance Period </th>
                           <th class="divTableCell blueItallic divSmall automatable2">Number of Prescriptions (not controlled) Generated and Transmitted Electronically</th>
                           <th class="divTableCell blueItallic divSmall automatable2">Number of Controlled Substances Generated and Transmitted Electronically</th>
                           <th class="divTableCell blueItallic divSmall automatable1">Prescription(s) Queried for Drug Formulary</th>
@@ -945,7 +945,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Number of Prescriptions Written during reporting/ performance period (not controlled)</th>
+                          <th class="divTableCell blueItallic divSmall ">Number of Prescriptions Written During Reporting / Performance Period (not controlled)</th>
                           <th class="divTableCell blueItallic divSmall automatable2">Number of Prescriptions (not controlled) Generated and Transmitted Electronically</th>
                           <th class="divTableCell blueItallic divSmall automatable1">Prescription(s) Queried for Drug Formulary</th>
                           <th class="divTableCell blueItallic divSmall  mips_2020">Provider 1</th>
@@ -1374,8 +1374,8 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Number of Prescriptions Written during reporting/ performance period (not controlled)</th>
-                          <th class="divTableCell blueItallic divSmall ">Number of Controlled Prescriptions Written during reporting/  performance period</th>
+                          <th class="divTableCell blueItallic divSmall ">Number of Prescriptions Written During Reporting / Performance Period (not controlled)</th>
+                          <th class="divTableCell blueItallic divSmall ">Number of Controlled Prescriptions Written During Reporting / Performance Period </th>
                           <th class="divTableCell blueItallic divSmall automatable2">Number of Prescriptions (not controlled) Generated and Transmitted Electronically</th>
                           <th class="divTableCell blueItallic divSmall automatable2">Number of Controlled Substances Generated and Transmitted Electronically</th>
                           <th class="divTableCell blueItallic divSmall automatable1">Prescription(s) Queried for Drug Formulary</th>
@@ -1794,7 +1794,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Number of Prescriptions Written during reporting/ performance period (not controlled)</th>
+                          <th class="divTableCell blueItallic divSmall ">Number of Prescriptions Written During Reporting / Performance Period (not controlled)</th>
                           <th class="divTableCell blueItallic divSmall automatable2">Number of Prescriptions (not controlled) Generated and Transmitted Electronically</th>
                           <th class="divTableCell blueItallic divSmall automatable1">Prescription(s) Queried for Drug Formulary</th>
                           <th class="divTableCell blueItallic divSmall  mips_2020">Provider 1</th>
@@ -2149,8 +2149,8 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Number of Prescriptions Written during reporting/ performance period (not controlled)</th>
-                          <th class="divTableCell blueItallic divSmall ">Number of Controlled Prescriptions Written during reporting/  performance period</th>
+                          <th class="divTableCell blueItallic divSmall ">Number of Prescriptions Written During Reporting / Performance Period (not controlled)</th>
+                          <th class="divTableCell blueItallic divSmall ">Number of Controlled Prescriptions Written During Reporting / Performance Period </th>
                           <th class="divTableCell blueItallic divSmall automatable2">Number of Prescriptions (not controlled) Generated and Transmitted Electronically</th>
                           <th class="divTableCell blueItallic divSmall automatable2">Number of Controlled Substances Generated and Transmitted Electronically</th>
                           <th class="divTableCell blueItallic divSmall automatable1">Prescription(s) Queried for Drug Formulary</th>
@@ -2482,7 +2482,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Number of Prescriptions Written during reporting/ performance period (not controlled)</th>
+                          <th class="divTableCell blueItallic divSmall ">Number of Prescriptions Written During Reporting / Performance Period (not controlled)</th>
                           <th class="divTableCell blueItallic divSmall automatable2">Number of Prescriptions (not controlled) Generated and Transmitted Electronically</th>
                           <th class="divTableCell blueItallic divSmall automatable1">Prescription(s) Queried for Drug Formulary</th>
                           <th class="divTableCell blueItallic divSmall  mips_2020">Provider 1</th>

--- a/exports/test_data/G2_EP_Required_Test_10.html
+++ b/exports/test_data/G2_EP_Required_Test_10.html
@@ -364,7 +364,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Medication Orders Created Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Medication Orders Created Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Medication Orders Created</th>
                           <th class="divTableCell blueItallic ">Number of Medication Orders Recorded Using CPOE</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -454,7 +454,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Medication Orders Created Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Medication Orders Created Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Medication Orders Created</th>
                           <th class="divTableCell blueItallic ">Number of Medication Orders Recorded Using CPOE</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -529,7 +529,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Medication Orders Created Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Medication Orders Created Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Medication Orders Created</th>
                           <th class="divTableCell blueItallic ">Number of Medication Orders Recorded Using CPOE</th>
                         <th class="divTableCell blueItallic">Records Total</th>

--- a/exports/test_data/G2_EP_Required_Test_11.html
+++ b/exports/test_data/G2_EP_Required_Test_11.html
@@ -364,7 +364,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Laboratory Orders Created Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Laboratory Orders Created Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Laboratory Orders Created</th>
                           <th class="divTableCell blueItallic ">Number of Laboratory Orders Recorded Using CPOE</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -454,7 +454,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Laboratory Orders Created Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Laboratory Orders Created Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Laboratory Orders Created</th>
                           <th class="divTableCell blueItallic ">Number of Laboratory Orders Recorded Using CPOE</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -529,7 +529,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Laboratory Orders Created Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Laboratory Orders Created Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Laboratory Orders Created</th>
                           <th class="divTableCell blueItallic ">Number of Laboratory Orders Recorded Using CPOE</th>
                         <th class="divTableCell blueItallic">Records Total</th>

--- a/exports/test_data/G2_EP_Required_Test_12.html
+++ b/exports/test_data/G2_EP_Required_Test_12.html
@@ -364,7 +364,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Diagnostic Imaging Orders Created Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Diagnostic Imaging Orders Created Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Diagnostic Imaging Orders Created</th>
                           <th class="divTableCell blueItallic ">Number of Diagnostic Imaging Orders Recorded Using CPOE</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -454,7 +454,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Diagnostic Imaging Orders Created Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Diagnostic Imaging Orders Created Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Diagnostic Imaging Orders Created</th>
                           <th class="divTableCell blueItallic ">Number of Diagnostic Imaging Orders Recorded Using CPOE</th>
                         <th class="divTableCell blueItallic">Records Total</th>
@@ -529,7 +529,7 @@
                       </tr>
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
-                          <th class="divTableCell blueItallic ">Diagnostic Imaging Orders Created Within or Outside Reporting Period</th>
+                          <th class="divTableCell blueItallic ">Diagnostic Imaging Orders Created Within Reporting Period</th>
                           <th class="divTableCell blueItallic ">Diagnostic Imaging Orders Created</th>
                           <th class="divTableCell blueItallic ">Number of Diagnostic Imaging Orders Recorded Using CPOE</th>
                         <th class="divTableCell blueItallic">Records Total</th>

--- a/exports/test_data/G2_EP_Required_Test_2a_.html
+++ b/exports/test_data/G2_EP_Required_Test_2a_.html
@@ -430,7 +430,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen  During or Outside EHR Reporting Period</th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During EHR Reporting Period</th>
                           <th class="divTableCell blueItallic divSmall automatable1">Patient or Authorized Representative Provided Access to View, Download, and Transmit Their Health Information within 48 hours (Medicaid) or 4 business days (MIPS)</th>
                           <th class="divTableCell blueItallic divSmall automatable1">Patient Health Information is Available to Access via API  within 48 hours (Medicaid) or 4 business days (MIPS)</th>
                           <th class="divTableCell blueItallic divSmall  mips_2020">Provider 1</th>
@@ -458,10 +458,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -513,10 +513,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -568,10 +568,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -623,10 +623,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
                                 <li class="divLi noWrap mips_2020">Not Seen</li>
                                 <li class="divLi noWrap medicaid_2020mips_2020">Not Seen</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -678,10 +678,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -758,7 +758,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen  During or Outside EHR Reporting Period</th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During EHR Reporting Period</th>
                           <th class="divTableCell blueItallic divSmall automatable1">Patient or Authorized Representative Provided Access to View, Download, and Transmit Their Health Information within 48 hours (Medicaid) or 4 business days (MIPS)</th>
                           <th class="divTableCell blueItallic divSmall automatable1">Patient Health Information is Available to Access via API  within 48 hours (Medicaid) or 4 business days (MIPS)</th>
                           <th class="divTableCell blueItallic divSmall  mips_2020">Provider 1</th>
@@ -786,10 +786,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter, during</li>
-                                <li class="divLi noWrap mips_2020">Second encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter, during</li>
-                                <li class="divLi noWrap mips_2020">Second encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter</li>
+                                <li class="divLi noWrap mips_2020">Second encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter</li>
+                                <li class="divLi noWrap mips_2020">Second encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -841,10 +841,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter, during</li>
-                                <li class="divLi noWrap mips_2020">Second encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter, during</li>
-                                <li class="divLi noWrap mips_2020">Second encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter</li>
+                                <li class="divLi noWrap mips_2020">Second encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter</li>
+                                <li class="divLi noWrap mips_2020">Second encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -896,10 +896,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter, during</li>
-                                <li class="divLi noWrap mips_2020">Second encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter, during</li>
-                                <li class="divLi noWrap mips_2020">Second encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter</li>
+                                <li class="divLi noWrap mips_2020">Second encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter</li>
+                                <li class="divLi noWrap mips_2020">Second encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -976,7 +976,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen  During or Outside EHR Reporting Period</th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During EHR Reporting Period</th>
                           <th class="divTableCell blueItallic divSmall automatable1">Patient or Authorized Representative Provided Access to View, Download, and Transmit Their Health Information within 48 hours (Medicaid) or 4 business days (MIPS)</th>
                           <th class="divTableCell blueItallic divSmall automatable1">Patient Health Information is Available to Access via API  within 48 hours (Medicaid) or 4 business days (MIPS)</th>
                           <th class="divTableCell blueItallic divSmall  mips_2020">Provider 1</th>
@@ -1004,10 +1004,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -1059,10 +1059,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -1114,10 +1114,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -1194,7 +1194,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen  During or Outside EHR Reporting Period</th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During EHR Reporting Period</th>
                           <th class="divTableCell blueItallic divSmall automatable1">Patient or Authorized Representative Provided Access to View, Download, and Transmit Their Health Information within 48 hours (Medicaid) or 4 business days (MIPS)</th>
                           <th class="divTableCell blueItallic divSmall automatable1">Patient Health Information is Available to Access via API  within 48 hours (Medicaid) or 4 business days (MIPS)</th>
                           <th class="divTableCell blueItallic divSmall  mips_2020">Provider 1</th>
@@ -1222,10 +1222,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -1277,10 +1277,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -1332,10 +1332,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -1412,7 +1412,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen  During or Outside EHR Reporting Period</th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During EHR Reporting Period</th>
                           <th class="divTableCell blueItallic divSmall automatable1">Patient or Authorized Representative Provided Access to View, Download, and Transmit Their Health Information within 48 hours (Medicaid) or 4 business days (MIPS)</th>
                           <th class="divTableCell blueItallic divSmall automatable1">Patient Health Information is Available to Access via API  within 48 hours (Medicaid) or 4 business days (MIPS)</th>
                           <th class="divTableCell blueItallic divSmall  mips_2020">Provider 1</th>
@@ -1440,10 +1440,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter</li>
                                 <li class="divLi noWrap mips_2020">Not Seen</li>
                                 <li class="divLi noWrap medicaid_2020mips_2020">Not Seen</li>
-                                <li class="divLi noWrap mips_2020">Second encounter, during</li>
+                                <li class="divLi noWrap mips_2020">Second encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">

--- a/exports/test_data/G2_EP_Required_Test_2b_.html
+++ b/exports/test_data/G2_EP_Required_Test_2b_.html
@@ -427,7 +427,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen  During or Outside EHR Reporting Period</th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During EHR Reporting Period</th>
                           <th class="divTableCell blueItallic divSmall automatable1">Patient or Authorized Representative Provided Access to View, Download, and Transmit Their Health Information within 48 hours (Medicaid) or 4 business days (MIPS)</th>
                           <th class="divTableCell blueItallic divSmall  mips_2020">Provider 1</th>
                           <th class="divTableCell blueItallic divSmall  mips_2020">Provider 2</th>
@@ -454,10 +454,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -501,10 +501,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -548,10 +548,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -595,10 +595,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
                                 <li class="divLi noWrap mips_2020">Not seen</li>
                                 <li class="divLi noWrap medicaid_2020mips_2020">Not seen</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -642,10 +642,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -713,7 +713,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen  During or Outside EHR Reporting Period</th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During EHR Reporting Period</th>
                           <th class="divTableCell blueItallic divSmall automatable1">Patient or Authorized Representative Provided Access to View, Download, and Transmit Their Health Information within 48 hours (Medicaid) or 4 business days (MIPS)</th>
                           <th class="divTableCell blueItallic divSmall  mips_2020">Provider 1</th>
                           <th class="divTableCell blueItallic divSmall  mips_2020">Provider 2</th>
@@ -740,10 +740,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter, during</li>
-                                <li class="divLi noWrap mips_2020">Second encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter, during</li>
-                                <li class="divLi noWrap mips_2020">Second encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter</li>
+                                <li class="divLi noWrap mips_2020">Second encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter</li>
+                                <li class="divLi noWrap mips_2020">Second encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -787,10 +787,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter, during</li>
-                                <li class="divLi noWrap mips_2020">Second encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter, during</li>
-                                <li class="divLi noWrap mips_2020">Second encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter</li>
+                                <li class="divLi noWrap mips_2020">Second encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter</li>
+                                <li class="divLi noWrap mips_2020">Second encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -834,10 +834,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter, during</li>
-                                <li class="divLi noWrap mips_2020">Second encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter, during</li>
-                                <li class="divLi noWrap mips_2020">Second encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter</li>
+                                <li class="divLi noWrap mips_2020">Second encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter</li>
+                                <li class="divLi noWrap mips_2020">Second encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -905,7 +905,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen  During or Outside EHR Reporting Period</th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During EHR Reporting Period</th>
                           <th class="divTableCell blueItallic divSmall ">Patient or Authorized Representative Provided Access to View, Download, and Transmit Their Health Information within 48 hours (Medicaid) or 4 business days (MIPS)</th>
                           <th class="divTableCell blueItallic divSmall  mips_2020">Provider 1</th>
                           <th class="divTableCell blueItallic divSmall  mips_2020">Provider 2</th>
@@ -932,10 +932,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -979,10 +979,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -1026,10 +1026,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -1097,7 +1097,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen  During or Outside EHR Reporting Period</th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During EHR Reporting Period</th>
                           <th class="divTableCell blueItallic divSmall automatable1">Patient or Authorized Representative Provided Access to View, Download, and Transmit Their Health Information within 48 hours (Medicaid) or 4 business days (MIPS)</th>
                           <th class="divTableCell blueItallic divSmall  mips_2020">Provider 1</th>
                           <th class="divTableCell blueItallic divSmall  mips_2020">Provider 2</th>
@@ -1124,10 +1124,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -1171,10 +1171,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -1218,10 +1218,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -1289,7 +1289,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen  During or Outside EHR Reporting Period</th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During EHR Reporting Period</th>
                           <th class="divTableCell blueItallic divSmall automatable1">Patient or Authorized Representative Provided Access to View, Download, and Transmit Their Health Information within 48 hours (Medicaid) or 4 business days (MIPS)</th>
                           <th class="divTableCell blueItallic divSmall  mips_2020">Provider 1</th>
                           <th class="divTableCell blueItallic divSmall  mips_2020">Provider 2</th>
@@ -1316,10 +1316,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter</li>
                                 <li class="divLi noWrap mips_2020">Not Seen</li>
                                 <li class="divLi noWrap medicaid_2020mips_2020">Not Seen</li>
-                                <li class="divLi noWrap mips_2020">Second encounter, during</li>
+                                <li class="divLi noWrap mips_2020">Second encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">

--- a/exports/test_data/G2_EP_Required_Test_2c_.html
+++ b/exports/test_data/G2_EP_Required_Test_2c_.html
@@ -430,7 +430,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen  During or Outside EHR Reporting Period</th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During EHR Reporting Period</th>
                           <th class="divTableCell blueItallic divSmall automatable1">Patient Health Information is Available to Access via API  within 48 hours (Medicaid) or 4 business days (MIPS)</th>
                           <th class="divTableCell blueItallic divSmall  mips_2020">Provider 1</th>
                           <th class="divTableCell blueItallic divSmall  mips_2020">Provider 2</th>
@@ -457,10 +457,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -504,10 +504,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -551,10 +551,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -598,10 +598,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
                                 <li class="divLi noWrap mips_2020">Not seen</li>
                                 <li class="divLi noWrap medicaid_2020mips_2020">Not seen</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -645,10 +645,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -716,7 +716,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen  During or Outside EHR Reporting Period</th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During EHR Reporting Period</th>
                           <th class="divTableCell blueItallic divSmall automatable1">Patient Health Information is Available to Access via API  within 48 hours (Medicaid) or 4 business days (MIPS)</th>
                           <th class="divTableCell blueItallic divSmall  mips_2020">Provider 1</th>
                           <th class="divTableCell blueItallic divSmall  mips_2020">Provider 2</th>
@@ -743,10 +743,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter, during</li>
-                                <li class="divLi noWrap mips_2020">Second encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter, during</li>
-                                <li class="divLi noWrap mips_2020">Second encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter</li>
+                                <li class="divLi noWrap mips_2020">Second encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter</li>
+                                <li class="divLi noWrap mips_2020">Second encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -790,10 +790,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter, during</li>
-                                <li class="divLi noWrap mips_2020">Second encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter, during</li>
-                                <li class="divLi noWrap mips_2020">Second encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter</li>
+                                <li class="divLi noWrap mips_2020">Second encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter</li>
+                                <li class="divLi noWrap mips_2020">Second encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -837,10 +837,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter, during</li>
-                                <li class="divLi noWrap mips_2020">Second encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter, during</li>
-                                <li class="divLi noWrap mips_2020">Second encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter</li>
+                                <li class="divLi noWrap mips_2020">Second encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter</li>
+                                <li class="divLi noWrap mips_2020">Second encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -908,7 +908,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen  During or Outside EHR Reporting Period</th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During EHR Reporting Period</th>
                           <th class="divTableCell blueItallic divSmall automatable1">Patient Health Information is Available to Access via API  within 48 hours (Medicaid) or 4 business days (MIPS)</th>
                           <th class="divTableCell blueItallic divSmall  mips_2020">Provider 1</th>
                           <th class="divTableCell blueItallic divSmall  mips_2020">Provider 2</th>
@@ -935,10 +935,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -982,10 +982,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -1029,10 +1029,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -1100,7 +1100,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen  During or Outside EHR Reporting Period</th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During EHR Reporting Period</th>
                           <th class="divTableCell blueItallic divSmall automatable1">Patient Health Information is Available to Access via API  within 48 hours (Medicaid) or 4 business days (MIPS)</th>
                           <th class="divTableCell blueItallic divSmall  mips_2020">Provider 1</th>
                           <th class="divTableCell blueItallic divSmall  mips_2020">Provider 2</th>
@@ -1127,10 +1127,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -1174,10 +1174,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -1221,10 +1221,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter, during</li>
-                                <li class="divLi noWrap mips_2020">First encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">First encounter</li>
+                                <li class="divLi noWrap mips_2020">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">
@@ -1292,7 +1292,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen  During or Outside EHR Reporting Period</th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During EHR Reporting Period</th>
                           <th class="divTableCell blueItallic divSmall automatable1">Patient Health Information is Available to Access via API  within 48 hours (Medicaid) or 4 business days (MIPS)</th>
                           <th class="divTableCell blueItallic divSmall  mips_2020">Provider 1</th>
                           <th class="divTableCell blueItallic divSmall  mips_2020">Provider 2</th>
@@ -1319,10 +1319,10 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter, during</li>
+                                <li class="divLi noWrap medicaid_2020mips_2020">Second encounter</li>
                                 <li class="divLi noWrap mips_2020">Not Seen</li>
                                 <li class="divLi noWrap medicaid_2020mips_2020">Not Seen</li>
-                                <li class="divLi noWrap mips_2020">Second encounter, during</li>
+                                <li class="divLi noWrap mips_2020">Second encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell automatable1">

--- a/exports/test_data/G2_EP_Required_Test_3.html
+++ b/exports/test_data/G2_EP_Required_Test_3.html
@@ -390,7 +390,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen During or Outside of Reporting / Performance Period</th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During Reporting / Performance Period</th>
                           <th class="divTableCell blueItallic divSmall ">CEHRT Identifies Patient-Specific Education Resources  During the  Calendar Year </th>
                           <th class="divTableCell blueItallic divSmall automatable1">EP/EC Provides Electronic Access to Patient-Specific Educational Resources Identified by CEHRT During the  Calendar Year</th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 1</th>
@@ -410,8 +410,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -445,8 +445,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -480,8 +480,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -515,7 +515,7 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
                                 <li class="divLi noWrap ">Not seen</li>
                             </ol>
                           </td>
@@ -550,8 +550,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -600,7 +600,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen During or Outside of Reporting / Performance Period</th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During Reporting / Performance Period</th>
                           <th class="divTableCell blueItallic divSmall ">CEHRT Identifies Patient-Specific Education Resources  During the  Calendar Year</th>
                           <th class="divTableCell blueItallic divSmall automatable1">EP/EC Provides Electronic Access to Patient-Specific Educational Resources Identified by CEHRT During the  Calendar Year</th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 1</th>
@@ -620,8 +620,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">Second encounter, during</li>
-                                <li class="divLi noWrap ">Second encounter, during</li>
+                                <li class="divLi noWrap ">Second encounter</li>
+                                <li class="divLi noWrap ">Second encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -655,8 +655,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">Second encounter, during</li>
-                                <li class="divLi noWrap ">Second encounter, during</li>
+                                <li class="divLi noWrap ">Second encounter</li>
+                                <li class="divLi noWrap ">Second encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -690,8 +690,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">Second encounter, during</li>
-                                <li class="divLi noWrap ">Second encounter, during</li>
+                                <li class="divLi noWrap ">Second encounter</li>
+                                <li class="divLi noWrap ">Second encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -740,7 +740,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen During or Outside of Reporting / Performance Period</th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During Reporting / Performance Period</th>
                           <th class="divTableCell blueItallic divSmall ">CEHRT Identifies Patient-Specific Education Resources  During the  Calendar Year</th>
                           <th class="divTableCell blueItallic divSmall automatable1">EP/EC Provides Electronic Access to Patient-Specific Educational Resources Identified by CEHRT During the  Calendar Year</th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 1</th>
@@ -760,8 +760,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -795,8 +795,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -830,8 +830,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -880,7 +880,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen During or Outside of Reporting / Performance Period</th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During Reporting / Performance Period</th>
                           <th class="divTableCell blueItallic divSmall ">CEHRT Identifies Patient-Specific Education Resources  During the  Calendar Year</th>
                           <th class="divTableCell blueItallic divSmall automatable1">EP/EC Provides Electronic Access to Patient-Specific Educational Resources Identified by CEHRT During the  Calendar Year</th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 1</th>
@@ -900,8 +900,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -935,8 +935,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -970,8 +970,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -1020,7 +1020,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen During or Outside of Reporting / Performance Period</th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During Reporting / Performance Period</th>
                           <th class="divTableCell blueItallic divSmall ">CEHRT Identifies Patient-Specific Education Resources  During the  Calendar Year</th>
                           <th class="divTableCell blueItallic divSmall automatable1">EP/EC Provides Electronic Access to Patient-Specific Educational Resources Identified by CEHRT During the  Calendar Year</th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 1</th>
@@ -1040,7 +1040,7 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">Second encounter, during</li>
+                                <li class="divLi noWrap ">Second encounter</li>
                                 <li class="divLi noWrap ">Not Seen</li>
                             </ol>
                           </td>

--- a/exports/test_data/G2_EP_Required_Test_4a_.html
+++ b/exports/test_data/G2_EP_Required_Test_4a_.html
@@ -381,7 +381,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen During or Outside Reporting Period </th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During Reporting Period </th>
                           <th class="divTableCell blueItallic divSmall ">Patient or Authorized Representative Viewed, Downloaded, or Transmitted their Information During the Calendar Year</th>
                           <th class="divTableCell blueItallic divSmall ">Patient Accessed Health Information Through API During the Calendar Year </th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 1</th>
@@ -401,8 +401,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -434,8 +434,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -467,8 +467,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -500,7 +500,7 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
                                 <li class="divLi noWrap ">Not seen</li>
                             </ol>
                           </td>
@@ -533,8 +533,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -579,7 +579,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen During or Outside Reporting Period </th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During Reporting Period </th>
                           <th class="divTableCell blueItallic divSmall ">Patient or Authorized Representative Viewed, Downloaded, or Transmitted their Information During the Calendar Year</th>
                           <th class="divTableCell blueItallic divSmall ">Patient Accessed Health Information Through API During the Calendar Year </th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 1</th>
@@ -599,8 +599,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">Second encounter, during</li>
-                                <li class="divLi noWrap ">Second encounter, during</li>
+                                <li class="divLi noWrap ">Second encounter</li>
+                                <li class="divLi noWrap ">Second encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -632,8 +632,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">Second encounter, during</li>
-                                <li class="divLi noWrap ">Second encounter, during</li>
+                                <li class="divLi noWrap ">Second encounter</li>
+                                <li class="divLi noWrap ">Second encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -665,8 +665,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">Second encounter, during</li>
-                                <li class="divLi noWrap ">Second encounter, during</li>
+                                <li class="divLi noWrap ">Second encounter</li>
+                                <li class="divLi noWrap ">Second encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -711,7 +711,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen During or Outside Reporting Period </th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During Reporting Period </th>
                           <th class="divTableCell blueItallic divSmall ">Patient or Authorized Representative Viewed, Downloaded, or Transmitted their Information During the Calendar Year</th>
                           <th class="divTableCell blueItallic divSmall ">Patient Accessed Health Information Through API During the Calendar Year </th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 1</th>
@@ -731,8 +731,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -764,8 +764,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -797,8 +797,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -843,7 +843,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen During or Outside Reporting Period </th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During Reporting Period </th>
                           <th class="divTableCell blueItallic divSmall ">Patient or Authorized Representative Viewed, Downloaded, or Transmitted their Information During the Calendar Year</th>
                           <th class="divTableCell blueItallic divSmall ">Patient Accessed Health Information Through API During the Calendar Year </th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 1</th>
@@ -863,8 +863,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -896,8 +896,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -929,8 +929,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -975,7 +975,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen During or Outside Reporting Period </th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During Reporting Period </th>
                           <th class="divTableCell blueItallic divSmall ">Patient or Authorized Representative Viewed, Downloaded, or Transmitted their Information During the Calendar Year</th>
                           <th class="divTableCell blueItallic divSmall ">Patient Accessed Health Information Through API During the Calendar Year </th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 1</th>
@@ -995,7 +995,7 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">Second encounter, during</li>
+                                <li class="divLi noWrap ">Second encounter</li>
                                 <li class="divLi noWrap ">Not Seen</li>
                             </ol>
                           </td>

--- a/exports/test_data/G2_EP_Required_Test_4b_.html
+++ b/exports/test_data/G2_EP_Required_Test_4b_.html
@@ -381,7 +381,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen During or Outside Reporting Period </th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During Reporting Period </th>
                           <th class="divTableCell blueItallic divSmall ">Patient or Authorized Representative Viewed, Downloaded, or Transmitted their Information During the Calendar Year</th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 1</th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 2</th>
@@ -400,8 +400,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -427,8 +427,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -454,8 +454,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -481,7 +481,7 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
                                 <li class="divLi noWrap ">Not seen</li>
                             </ol>
                           </td>
@@ -508,8 +508,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -547,7 +547,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen During or Outside Reporting Period </th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During Reporting Period </th>
                           <th class="divTableCell blueItallic divSmall ">Patient or Authorized Representative Viewed, Downloaded, or Transmitted their Information During the Calendar Year</th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 1</th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 2</th>
@@ -566,8 +566,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">Second encounter, during</li>
-                                <li class="divLi noWrap ">Second encounter, during</li>
+                                <li class="divLi noWrap ">Second encounter</li>
+                                <li class="divLi noWrap ">Second encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -593,8 +593,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">Second encounter, during</li>
-                                <li class="divLi noWrap ">Second encounter, during</li>
+                                <li class="divLi noWrap ">Second encounter</li>
+                                <li class="divLi noWrap ">Second encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -620,8 +620,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">Second encounter, during</li>
-                                <li class="divLi noWrap ">Second encounter, during</li>
+                                <li class="divLi noWrap ">Second encounter</li>
+                                <li class="divLi noWrap ">Second encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -659,7 +659,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen During or Outside Reporting Period </th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During Reporting Period </th>
                           <th class="divTableCell blueItallic divSmall ">Patient or Authorized Representative Viewed, Downloaded, or Transmitted their Information During the Calendar Year</th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 1</th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 2</th>
@@ -678,8 +678,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -705,8 +705,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -732,8 +732,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -771,7 +771,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen During or Outside Reporting Period </th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During Reporting Period </th>
                           <th class="divTableCell blueItallic divSmall ">Patient or Authorized Representative Viewed, Downloaded, or Transmitted their Information During the Calendar Year</th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 1</th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 2</th>
@@ -790,8 +790,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -817,8 +817,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -844,8 +844,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -883,7 +883,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen During or Outside Reporting Period </th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During Reporting Period </th>
                           <th class="divTableCell blueItallic divSmall ">Patient or Authorized Representative Viewed, Downloaded, or Transmitted their Information During the Calendar Year</th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 1</th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 2</th>
@@ -902,7 +902,7 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">Second encounter, during</li>
+                                <li class="divLi noWrap ">Second encounter</li>
                                 <li class="divLi noWrap ">Not Seen</li>
                             </ol>
                           </td>

--- a/exports/test_data/G2_EP_Required_Test_4c_.html
+++ b/exports/test_data/G2_EP_Required_Test_4c_.html
@@ -381,7 +381,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen During or Outside Reporting Period </th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During Reporting Period </th>
                           <th class="divTableCell blueItallic divSmall ">Patient Accessed Health Information Through API During the Calendar Year </th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 1</th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 2</th>
@@ -400,8 +400,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -427,8 +427,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -454,8 +454,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -481,7 +481,7 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
                                 <li class="divLi noWrap ">Not seen</li>
                             </ol>
                           </td>
@@ -508,8 +508,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -547,7 +547,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen During or Outside Reporting Period </th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During Reporting Period </th>
                           <th class="divTableCell blueItallic divSmall ">Patient Accessed Health Information Through API During the Calendar Year </th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 1</th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 2</th>
@@ -566,8 +566,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">Second encounter, during</li>
-                                <li class="divLi noWrap ">Second encounter, during</li>
+                                <li class="divLi noWrap ">Second encounter</li>
+                                <li class="divLi noWrap ">Second encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -593,8 +593,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">Second encounter, during</li>
-                                <li class="divLi noWrap ">Second encounter, during</li>
+                                <li class="divLi noWrap ">Second encounter</li>
+                                <li class="divLi noWrap ">Second encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -620,8 +620,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">Second encounter, during</li>
-                                <li class="divLi noWrap ">Second encounter, during</li>
+                                <li class="divLi noWrap ">Second encounter</li>
+                                <li class="divLi noWrap ">Second encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -659,7 +659,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen During or Outside Reporting Period </th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During Reporting Period </th>
                           <th class="divTableCell blueItallic divSmall ">Patient Accessed Health Information Through API During the Calendar Year </th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 1</th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 2</th>
@@ -678,8 +678,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -705,8 +705,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -732,8 +732,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -771,7 +771,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen During or Outside Reporting Period </th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During Reporting Period </th>
                           <th class="divTableCell blueItallic divSmall ">Patient Accessed Health Information Through API During the Calendar Year </th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 1</th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 2</th>
@@ -790,8 +790,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -817,8 +817,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -844,8 +844,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -883,7 +883,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen During or Outside Reporting Period </th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During Reporting Period </th>
                           <th class="divTableCell blueItallic divSmall ">Patient Accessed Health Information Through API During the Calendar Year </th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 1</th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 2</th>
@@ -902,7 +902,7 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">Second encounter, during</li>
+                                <li class="divLi noWrap ">Second encounter</li>
                                 <li class="divLi noWrap ">Not Seen</li>
                             </ol>
                           </td>

--- a/exports/test_data/G2_EP_Required_Test_5.html
+++ b/exports/test_data/G2_EP_Required_Test_5.html
@@ -396,7 +396,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen  During or Outside Reporting/Performance Period</th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During Reporting/Performance Period</th>
                           <th class="divTableCell blueItallic divSmall ">Patient or Patient Representative Sends Secure Electronic Message to EP/EC During the Calendar Year</th>
                           <th class="divTableCell blueItallic divSmall ">EP/EC Replies to Secure Electronic Message from Patient or Patient Representative During the Calendar Year</th>
                           <th class="divTableCell blueItallic divSmall ">EP/EC Sends Secure Electronic Message to Patient or Patient Representative During the Calendar Year</th>
@@ -418,8 +418,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -465,8 +465,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -512,8 +512,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -559,7 +559,7 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
                                 <li class="divLi noWrap ">Not seen</li>
                             </ol>
                           </td>
@@ -606,8 +606,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -670,7 +670,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen  During or Outside Reporting/Performance Period</th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During Reporting/Performance Period</th>
                           <th class="divTableCell blueItallic divSmall ">Patient or Patient Representative Sends Secure Electronic Message to EP/EC During the Calendar Year</th>
                           <th class="divTableCell blueItallic divSmall ">EP/EC Replies to Secure Electronic Message from Patient or Patient Representative During the Calendar Year</th>
                           <th class="divTableCell blueItallic divSmall ">EP/EC Sends Secure Electronic Message to Patient or Patient Representative During the Calendar Year</th>
@@ -692,8 +692,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">Second encounter, during</li>
-                                <li class="divLi noWrap ">Second encounter, during</li>
+                                <li class="divLi noWrap ">Second encounter</li>
+                                <li class="divLi noWrap ">Second encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -739,8 +739,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">Second encounter, during</li>
-                                <li class="divLi noWrap ">Second encounter, during</li>
+                                <li class="divLi noWrap ">Second encounter</li>
+                                <li class="divLi noWrap ">Second encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -786,8 +786,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">Second encounter, during</li>
-                                <li class="divLi noWrap ">Second encounter, during</li>
+                                <li class="divLi noWrap ">Second encounter</li>
+                                <li class="divLi noWrap ">Second encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -850,7 +850,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen  During or Outside Reporting/Performance Period</th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During Reporting/Performance Period</th>
                           <th class="divTableCell blueItallic divSmall ">Patient or Patient Representative Sends Secure Electronic Message to EP/EC During the Calendar Year</th>
                           <th class="divTableCell blueItallic divSmall ">EP/EC Replies to Secure Electronic Message from Patient or Patient Representative During the Calendar Year</th>
                           <th class="divTableCell blueItallic divSmall ">EP/EC Sends Secure Electronic Message to Patient or Patient Representative During the Calendar Year</th>
@@ -872,8 +872,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -919,8 +919,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -966,8 +966,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -1030,7 +1030,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen  During or Outside Reporting/Performance Period</th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During Reporting/Performance Period</th>
                           <th class="divTableCell blueItallic divSmall ">Patient or Patient Representative Sends Secure Electronic Message to EP/EC During the Calendar Year</th>
                           <th class="divTableCell blueItallic divSmall ">EP/EC Replies to Secure Electronic Message from Patient or Patient Representative During the Calendar Year</th>
                           <th class="divTableCell blueItallic divSmall ">EP/EC Sends Secure Electronic Message to Patient or Patient Representative During the Calendar Year</th>
@@ -1052,8 +1052,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -1099,8 +1099,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -1146,8 +1146,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -1210,7 +1210,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen  During or Outside Reporting/Performance Period</th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen During Reporting/Performance Period</th>
                           <th class="divTableCell blueItallic divSmall ">Patient or Patient Representative Sends Secure Electronic Message to EP/EC During the Calendar Year</th>
                           <th class="divTableCell blueItallic divSmall ">EP/EC Replies to Secure Electronic Message from Patient or Patient Representative During the Calendar Year</th>
                           <th class="divTableCell blueItallic divSmall ">EP/EC Sends Secure Electronic Message to Patient or Patient Representative During the Calendar Year</th>
@@ -1232,7 +1232,7 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">Second encounter, during</li>
+                                <li class="divLi noWrap ">Second encounter</li>
                                 <li class="divLi noWrap ">Not Seen</li>
                             </ol>
                           </td>

--- a/exports/test_data/G2_EP_Required_Test_6.html
+++ b/exports/test_data/G2_EP_Required_Test_6.html
@@ -375,7 +375,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen Within or Outside Reporting/Performance Period </th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen Within Reporting/Performance Period </th>
                           <th class="divTableCell blueItallic divSmall ">Patient Data From Non-Clinical Settings Captured During Reporting/Performance Period</th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 1</th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 2</th>
@@ -394,8 +394,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -421,8 +421,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -448,8 +448,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -475,7 +475,7 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
                                 <li class="divLi noWrap ">Not seen</li>
                             </ol>
                           </td>
@@ -502,8 +502,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -541,7 +541,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen Within or Outside Reporting/Performance Period </th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen Within Reporting/Performance Period </th>
                           <th class="divTableCell blueItallic divSmall ">Patient Data From Non-Clinical Settings Captured During Reporting/Performance Period</th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 1</th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 2</th>
@@ -560,8 +560,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">Second encounter, during</li>
-                                <li class="divLi noWrap ">Second encounter, during</li>
+                                <li class="divLi noWrap ">Second encounter</li>
+                                <li class="divLi noWrap ">Second encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -587,8 +587,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">Second encounter, during</li>
-                                <li class="divLi noWrap ">Second encounter, during</li>
+                                <li class="divLi noWrap ">Second encounter</li>
+                                <li class="divLi noWrap ">Second encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -614,8 +614,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">Second encounter, during</li>
-                                <li class="divLi noWrap ">Second encounter, during</li>
+                                <li class="divLi noWrap ">Second encounter</li>
+                                <li class="divLi noWrap ">Second encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -653,7 +653,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen Within or Outside Reporting/Performance Period</th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen Within Reporting/Performance Period</th>
                           <th class="divTableCell blueItallic divSmall ">Patient Data From Non-Clinical Settings Captured During Reporting/Performance Period</th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 1</th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 2</th>
@@ -672,8 +672,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -699,8 +699,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -726,8 +726,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -765,7 +765,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen Within or Outside Reporting/Performance Period</th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen Within Reporting/Performance Period</th>
                           <th class="divTableCell blueItallic divSmall ">Patient Data From Non-Clinical Settings Captured During Reporting/Performance Period</th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 1</th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 2</th>
@@ -784,8 +784,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -811,8 +811,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -838,8 +838,8 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">First encounter, during</li>
-                                <li class="divLi noWrap ">First encounter, during</li>
+                                <li class="divLi noWrap ">First encounter</li>
+                                <li class="divLi noWrap ">First encounter</li>
                             </ol>
                           </td>
                           <td class="divTableCell ">
@@ -877,7 +877,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Patient Seen Within or Outside Reporting/Performance Period</th>
+                          <th class="divTableCell blueItallic divSmall ">Patient Seen Within Reporting/Performance Period</th>
                           <th class="divTableCell blueItallic divSmall ">Patient Data From Non-Clinical Settings Captured During Reporting/Performance Period</th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 1</th>
                           <th class="divTableCell blueItallic divSmall  ">Provider 2</th>
@@ -896,7 +896,7 @@
                           </td>
                           <td class="divTableCell ">
                             <ol>
-                                <li class="divLi noWrap ">Second encounter, during</li>
+                                <li class="divLi noWrap ">Second encounter</li>
                                 <li class="divLi noWrap ">Not Seen</li>
                             </ol>
                           </td>

--- a/exports/test_data/G2_EP_Required_Test_9.html
+++ b/exports/test_data/G2_EP_Required_Test_9.html
@@ -372,7 +372,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Transitioned, Referred, New, or Existing Patient Within Reporting/ Performance Period </th>
+                          <th class="divTableCell blueItallic divSmall ">Transitioned, Referred, New, or Existing Patient Within Reporting / Performance Period </th>
                           <th class="divTableCell blueItallic divSmall ">Medication Reconciliation During the Calendar Year</th>
                           <th class="divTableCell blueItallic divSmall ">Medication Allergy Reconciliation During the Calendar Year</th>
                           <th class="divTableCell blueItallic divSmall ">Current Problem List Reconciliation During the Calendar Year</th>
@@ -605,7 +605,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Transitioned, Referred, New, or Existing Patient Within Reporting/ Performance Period </th>
+                          <th class="divTableCell blueItallic divSmall ">Transitioned, Referred, New, or Existing Patient Within Reporting / Performance Period </th>
                           <th class="divTableCell blueItallic divSmall ">Medication Reconciliation During the Calendar Year</th>
                           <th class="divTableCell blueItallic divSmall ">Medication Allergy Reconciliation During the Calendar Year</th>
                           <th class="divTableCell blueItallic divSmall ">Current Problem List Reconciliation During the Calendar Year</th>
@@ -796,7 +796,7 @@
                       <tr class="divTableRow">
                         <th class="divTableCell blueItallic">Patient</th>
                         <th class="divTableCell blueItallic">Provider Information</th>
-                          <th class="divTableCell blueItallic divSmall ">Transitioned, Referred, New, or Existing Patient Within Reporting/ Performance Period </th>
+                          <th class="divTableCell blueItallic divSmall ">Transitioned, Referred, New, or Existing Patient Within Reporting / Performance Period </th>
                           <th class="divTableCell blueItallic divSmall ">Medication Reconciliation During the Calendar Year</th>
                           <th class="divTableCell blueItallic divSmall ">Medication Allergy Reconciliation During the Calendar Year</th>
                           <th class="divTableCell blueItallic divSmall ">Current Problem List Reconciliation During the Calendar Year</th>

--- a/index.html
+++ b/index.html
@@ -332,6 +332,6 @@
           </div>
         </div>
         <br/>
-        <div>Version: 2.3 - Exported 2021-05-10 by the <a href="https://github.com/projectcypress/promoting-interoperability-test-artifacts">promoting-interoperability-test-artifacts</a> generator</div>
+        <div>Version: 2.4 - Exported 2021-06-25 by the <a href="https://github.com/projectcypress/promoting-interoperability-test-artifacts">promoting-interoperability-test-artifacts</a> generator</div>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -332,6 +332,6 @@
           </div>
         </div>
         <br/>
-        <div>Version: 2.4 - Exported 2021-06-25 by the <a href="https://github.com/projectcypress/promoting-interoperability-test-artifacts">promoting-interoperability-test-artifacts</a> generator</div>
+        <div>Version: 2.4 - Exported 2021-06-28 by the <a href="https://github.com/projectcypress/promoting-interoperability-test-artifacts">promoting-interoperability-test-artifacts</a> generator</div>
   </body>
 </html>

--- a/lib/g1-g2-export/index_export.mustache
+++ b/lib/g1-g2-export/index_export.mustache
@@ -32,6 +32,6 @@
           </div>
         </div>
         <br/>
-        <div>Version: 2.3 - Exported {{{today_date}}} by the <a href="https://github.com/projectcypress/promoting-interoperability-test-artifacts">promoting-interoperability-test-artifacts</a> generator</div>
+        <div>Version: 2.4 - Exported {{{today_date}}} by the <a href="https://github.com/projectcypress/promoting-interoperability-test-artifacts">promoting-interoperability-test-artifacts</a> generator</div>
   </body>
 </html>

--- a/resources/RT1/EH_RT1_G1.json
+++ b/resources/RT1/EH_RT1_G1.json
@@ -48,23 +48,23 @@
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "New, Within"
+                  "entry_value": "New"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "New, Within"
+                  "entry_value": "New"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "Changed, Within"
+                  "entry_value": "Changed"
                 },
                 {
                   "patient_id": "Allan Summers",
-                  "entry_value": "Changed, Within"
+                  "entry_value": "Changed"
                 },
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "New, Within"
+                  "entry_value": "New"
                 }
               ]
             },
@@ -249,23 +249,23 @@
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "New, Within"
+                  "entry_value": "New"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "New, Within"
+                  "entry_value": "New"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "Changed, Within"
+                  "entry_value": "Changed"
                 },
                 {
                   "patient_id": "Allan Summers",
-                  "entry_value": "Changed, Within"
+                  "entry_value": "Changed"
                 },
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "New, Within"
+                  "entry_value": "New"
                 }
               ]
             },
@@ -421,19 +421,19 @@
               "entry_values": [
                 {
                   "patient_id": "Anthony Edwards",
-                  "entry_value": "New, Within"
+                  "entry_value": "New"
                 },
                 {
                   "patient_id": "Bruce Hall",
-                  "entry_value": "New, Within"
+                  "entry_value": "New"
                 },
                 {
                   "patient_id": "Debra Steele",
-                  "entry_value": "Changed, Within"
+                  "entry_value": "Changed"
                 },
                 {
                   "patient_id": "Allan Summers",
-                  "entry_value": "Changed, Within"
+                  "entry_value": "Changed"
                 }
               ]
             },
@@ -593,19 +593,19 @@
               "entry_values": [
                 {
                   "patient_id": "Anthony Edwards",
-                  "entry_value": "New, Within"
+                  "entry_value": "New"
                 },
                 {
                   "patient_id": "Bruce Hall",
-                  "entry_value": "New, Within"
+                  "entry_value": "New"
                 },
                 {
                   "patient_id": "Debra Steele",
-                  "entry_value": "Changed, Within"
+                  "entry_value": "Changed"
                 },
                 {
                   "patient_id": "Allan Summers",
-                  "entry_value": "Changed, Within"
+                  "entry_value": "Changed"
                 }
               ]
             },

--- a/resources/RT1/EH_RT1_G1.json
+++ b/resources/RT1/EH_RT1_G1.json
@@ -24,7 +24,7 @@
   "test_data_notes": [
     "The set of calculations including controlled substances and the set of calculations excluding controlled substances are both required.  If a Health IT Module is not able to transmit controlled substances, it is at the discretion of the ATL to not test the controlled substance calculations.",
     "If a Health IT Module automatically transmits a prescription electronically when it is generated, it is at the discretion of the ATL not to test scenarios that assume this is not automatic.",
-    "If a Health IT Module automatically queries for a drug formulary upon every prescription that is generated, it is at the discretion of the ATL not to test scenarios that assume this is not automatic. Additionally, the 2021 specification for Medicare has removed the requirement for formulary checking as part of the calculations.",
+    "If a Health IT Module automatically queries for a drug formulary upon every prescription that is generated, it is at the discretion of the ATL not to test scenarios that assume this is not automatic. Additionally, the 2021 specification for Medicare has removed the requirement for formulary checking as part of the calculations (Select 'Hide - Automated Drug Queries' to remove this step from the test data).",
     "If a Health IT Module can only send changes electronically, it is at the discretion of the ATL not to test scenarios that assume a change could be sent via non-electronic means.",
     "The scenarios that test changed prescriptions assume that the original prescription was written electronically.",
     "Test data supply: ONC and Vendor-supplied. ONC provides the Test Data Scenarios and parameters; the Vendor will supply the Electronic Prescription entry and formulary details."

--- a/resources/RT1/EH_RT1_G1.json
+++ b/resources/RT1/EH_RT1_G1.json
@@ -24,7 +24,7 @@
   "test_data_notes": [
     "The set of calculations including controlled substances and the set of calculations excluding controlled substances are both required.  If a Health IT Module is not able to transmit controlled substances, it is at the discretion of the ATL to not test the controlled substance calculations.",
     "If a Health IT Module automatically transmits a prescription electronically when it is generated, it is at the discretion of the ATL not to test scenarios that assume this is not automatic.",
-    "If a Health IT Module automatically queries for a drug formulary upon every prescription that is generated, it is at the discretion of the ATL not to test scenarios that assume this is not automatic.",
+    "If a Health IT Module automatically queries for a drug formulary upon every prescription that is generated, it is at the discretion of the ATL not to test scenarios that assume this is not automatic. Additionally, the 2021 specification for Medicare has removed the requirement for formulary checking as part of the calculations.",
     "If a Health IT Module can only send changes electronically, it is at the discretion of the ATL not to test scenarios that assume a change could be sent via non-electronic means.",
     "The scenarios that test changed prescriptions assume that the original prescription was written electronically.",
     "Test data supply: ONC and Vendor-supplied. ONC provides the Test Data Scenarios and parameters; the Vendor will supply the Electronic Prescription entry and formulary details."
@@ -43,7 +43,7 @@
           "segment_title": "Includes controlled substances", 
           "segment_entries": [
             {
-              "entry_title": "Prescriptions  (New, Changed) Written Within or Outside the Reporting Period",
+              "entry_title": "Prescriptions  (New, Changed) Written Within the Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -244,7 +244,7 @@
           "segment_title": "Excludes controlled substances",
           "segment_entries": [
             {
-              "entry_title": "Prescriptions  (New, Changed) Written Within or Outside the Reporting Period",
+              "entry_title": "Prescriptions  (New, Changed) Written Within the Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -416,7 +416,7 @@
           "segment_title": "Includes controlled substances",
           "segment_entries": [
             {
-              "entry_title": "Prescriptions  (New, Changed) Written Within or Outside the Reporting Period",
+              "entry_title": "Prescriptions  (New, Changed) Written Within the Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -588,7 +588,7 @@
           "segment_title": "Excludes controlled substances",
           "segment_entries": [
             {
-              "entry_title": "Prescriptions  (New, Changed) Written Within or Outside the Reporting Period",
+              "entry_title": "Prescriptions  (New, Changed) Written Within the Reporting Period",
               "denom": true,
               "entry_values": [
                 {

--- a/resources/RT1/EH_RT1_G2.json
+++ b/resources/RT1/EH_RT1_G2.json
@@ -24,7 +24,7 @@
   "test_data_notes": [
     "The set of calculations including controlled substances and the set of calculations excluding controlled substances are both required.  If a Health IT Module is not able to transmit controlled substances, it is at the discretion of the ATL to not test the controlled substance calculations.",
     "If a Health IT Module automatically transmits a prescription electronically when it is generated, it is at the discretion of the ATL not to test scenarios that assume this is not automatic.",
-    "If a Health IT Module automatically queries for a drug formulary upon every prescription that is generated, it is at the discretion of the ATL not to test scenarios that assume this is not automatic. Additionally, the 2021 specification for Medicare has removed the requirement for formulary checking as part of the calculations.",
+    "If a Health IT Module automatically queries for a drug formulary upon every prescription that is generated, it is at the discretion of the ATL not to test scenarios that assume this is not automatic. Additionally, the 2021 specification for Medicare has removed the requirement for formulary checking as part of the calculations (Select 'Hide - Automated Drug Queries' to remove this step from the test data).",
     "If a Health IT Module can only send changes electronically, it is at the discretion of the ATL not to test scenarios that assume a change could be sent via non-electronic means.",
     "The scenarios that test changed prescriptions assume that the original prescription was written electronically.",
     "Test data supply: ONC and Vendor-supplied. ONC provides the Test Data Scenarios and parameters; the Vendor will supply the Electronic Prescription entry and formulary details."

--- a/resources/RT1/EH_RT1_G2.json
+++ b/resources/RT1/EH_RT1_G2.json
@@ -24,7 +24,7 @@
   "test_data_notes": [
     "The set of calculations including controlled substances and the set of calculations excluding controlled substances are both required.  If a Health IT Module is not able to transmit controlled substances, it is at the discretion of the ATL to not test the controlled substance calculations.",
     "If a Health IT Module automatically transmits a prescription electronically when it is generated, it is at the discretion of the ATL not to test scenarios that assume this is not automatic.",
-    "If a Health IT Module automatically queries for a drug formulary upon every prescription that is generated, it is at the discretion of the ATL not to test scenarios that assume this is not automatic.",
+    "If a Health IT Module automatically queries for a drug formulary upon every prescription that is generated, it is at the discretion of the ATL not to test scenarios that assume this is not automatic. Additionally, the 2021 specification for Medicare has removed the requirement for formulary checking as part of the calculations.",
     "If a Health IT Module can only send changes electronically, it is at the discretion of the ATL not to test scenarios that assume a change could be sent via non-electronic means.",
     "The scenarios that test changed prescriptions assume that the original prescription was written electronically.",
     "Test data supply: ONC and Vendor-supplied. ONC provides the Test Data Scenarios and parameters; the Vendor will supply the Electronic Prescription entry and formulary details."
@@ -44,7 +44,7 @@
           "segment_title": "Includes controlled substances", 
           "segment_entries": [
             {
-              "entry_title": "Prescriptions  (New, Changed) Written Within or Outside the Reporting Period",
+              "entry_title": "Prescriptions  (New, Changed) Written Within the Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -251,7 +251,7 @@
           "segment_title": "Excludes controlled substances",
           "segment_entries": [
             {
-              "entry_title": "Prescriptions  (New, Changed) Written Within or Outside the Reporting Period",
+              "entry_title": "Prescriptions  (New, Changed) Written Within the Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -431,7 +431,7 @@
           "segment_title": "Includes controlled substances",
           "segment_entries": [
             {
-              "entry_title": "Prescriptions  (New, Changed) Written Within or Outside the Reporting Period",
+              "entry_title": "Prescriptions  (New, Changed) Written Within the Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -608,7 +608,7 @@
           "segment_title": "Excludes controlled substances",
           "segment_entries": [
             {
-              "entry_title": "Prescriptions  (New, Changed) Written Within or Outside the Reporting Period",
+              "entry_title": "Prescriptions  (New, Changed) Written Within the Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -746,7 +746,7 @@
           "segment_title": "Includes controlled substances",
           "segment_entries": [
             {
-              "entry_title": "Prescriptions  (New, Changed) Written Within or Outside the Reporting Period",
+              "entry_title": "Prescriptions  (New, Changed) Written Within the Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -923,7 +923,7 @@
           "segment_title": "Excludes controlled substances",
           "segment_entries": [
             {
-              "entry_title": "Prescriptions  (New, Changed) Written Within or Outside the Reporting Period",
+              "entry_title": "Prescriptions  (New, Changed) Written Within the Reporting Period",
               "denom": true,
               "entry_values": [
                 {

--- a/resources/RT1/EH_RT1_G2.json
+++ b/resources/RT1/EH_RT1_G2.json
@@ -49,23 +49,23 @@
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "New, Within"
+                  "entry_value": "New"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "New, Within"
+                  "entry_value": "New"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "Changed, Within"
+                  "entry_value": "Changed"
                 },
                 {
                   "patient_id": "Allan Summers",
-                  "entry_value": "Changed, Within"
+                  "entry_value": "Changed"
                 },
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "New, Within"
+                  "entry_value": "New"
                 }
               ]
             },
@@ -256,23 +256,23 @@
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "New, Within"
+                  "entry_value": "New"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "New, Within"
+                  "entry_value": "New"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "Changed, Within"
+                  "entry_value": "Changed"
                 },
                 {
                   "patient_id": "Allan Summers",
-                  "entry_value": "Changed, Within"
+                  "entry_value": "Changed"
                 },
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "New, Within"
+                  "entry_value": "New"
                 }
               ]
             },
@@ -436,19 +436,19 @@
               "entry_values": [
                 {
                   "patient_id": "Anthony Edwards",
-                  "entry_value": "New, Within"
+                  "entry_value": "New"
                 },
                 {
                   "patient_id": "Bruce Hall",
-                  "entry_value": "New, Within"
+                  "entry_value": "New"
                 },
                 {
                   "patient_id": "Debra Steele",
-                  "entry_value": "Changed, Within"
+                  "entry_value": "Changed"
                 },
                 {
                   "patient_id": "Allan Summers",
-                  "entry_value": "Changed, Within"
+                  "entry_value": "Changed"
                 }
               ]
             },
@@ -613,19 +613,19 @@
               "entry_values": [
                 {
                   "patient_id": "Anthony Edwards",
-                  "entry_value": "New, Within"
+                  "entry_value": "New"
                 },
                 {
                   "patient_id": "Bruce Hall",
-                  "entry_value": "New, Within"
+                  "entry_value": "New"
                 },
                 {
                   "patient_id": "Debra Steele",
-                  "entry_value": "Changed, Within"
+                  "entry_value": "Changed"
                 },
                 {
                   "patient_id": "Allan Summers",
-                  "entry_value": "Changed, Within"
+                  "entry_value": "Changed"
                 }
               ]
             },
@@ -751,19 +751,19 @@
               "entry_values": [
                 {
                   "patient_id": "Debra Price",
-                  "entry_value": "New, Within"
+                  "entry_value": "New"
                 },
                 {
                   "patient_id": "Mark Gordon",
-                  "entry_value": "New, Within"
+                  "entry_value": "New"
                 },
                 {
                   "patient_id": "Gabriel Brady",
-                  "entry_value": "Changed, Within"
+                  "entry_value": "Changed"
                 },
                 {
                   "patient_id": "Kirk Patterson",
-                  "entry_value": "Changed, Within"
+                  "entry_value": "Changed"
                 }
               ]
             },
@@ -928,19 +928,19 @@
               "entry_values": [
                 {
                   "patient_id": "Debra Price",
-                  "entry_value": "New, Within"
+                  "entry_value": "New"
                 },
                 {
                   "patient_id": "Mark Gordon",
-                  "entry_value": "New, Within"
+                  "entry_value": "New"
                 },
                 {
                   "patient_id": "Gabriel Brady",
-                  "entry_value": "Changed, Within"
+                  "entry_value": "Changed"
                 },
                 {
                   "patient_id": "Kirk Patterson",
-                  "entry_value": "Changed, Within"
+                  "entry_value": "Changed"
                 }
               ]
             },

--- a/resources/RT1/EP_RT1_G1.json
+++ b/resources/RT1/EP_RT1_G1.json
@@ -24,7 +24,7 @@
   "test_data_notes": [
     "The set of calculations including controlled substances and the set of calculations excluding controlled substances are both required.  If a Health IT Module is not able to transmit controlled substances, it is at the discretion of the ONC-ATL to not test the controlled substance calculations.",
     "If a Health IT Module automatically transmits a prescription electronically when it is generated, it is at the discretion of the ATL not to test scenarios that assume this is not automatic.",
-    "If a Health IT Module automatically queries for a drug formulary upon every prescription that is generated, it is at the discretion of the ATL not to test scenarios that assume this is not automatic. Additionally, the 2021 specification for MIPS has removed the requirement for formulary checking as part of the calculations.",
+    "If a Health IT Module automatically queries for a drug formulary upon every prescription that is generated, it is at the discretion of the ATL not to test scenarios that assume this is not automatic. Additionally, the 2021 specification for MIPS has removed the requirement for formulary checking as part of the calculations (Select 'Hide - Automated Drug Queries' to remove this step from the test data).",
     "If a Health IT Module can only send changes electronically, it is at the discretion of the ATL not to test scenarios that assume a change could be sent via non-electronic means.  ",
     "The scenarios that test changed prescriptions assume that the original prescription was written electronically.",
     "Test data supply: ONC and Vendor-supplied. ONC provides the Test Data Scenarios and parameters; the Vendor will supply the Electronic Prescription entry and formulary details."

--- a/resources/RT1/EP_RT1_G1.json
+++ b/resources/RT1/EP_RT1_G1.json
@@ -43,7 +43,7 @@
           "segment_title": "Includes controlled substances", 
           "segment_entries": [
             {
-              "entry_title": "Number of Prescriptions Written during reporting/ performance period (not controlled)",
+              "entry_title": "Number of Prescriptions Written During Reporting / Performance Period (not controlled)",
               "denom": true,
               "entry_values": [
                 {
@@ -69,7 +69,7 @@
               ]
             },
             {
-              "entry_title": "Number of Controlled Prescriptions Written during reporting/  performance period",
+              "entry_title": "Number of Controlled Prescriptions Written During Reporting / Performance Period ",
               "denom": true,
               "entry_values": [
                 {
@@ -218,7 +218,7 @@
           "segment_title": "Excludes controlled substances",
           "segment_entries": [
             {
-              "entry_title": "Number of Prescriptions Written during reporting/ performance period (not controlled)",
+              "entry_title": "Number of Prescriptions Written During Reporting / Performance Period (not controlled)",
               "denom": true,
               "entry_values": [
                 {
@@ -364,7 +364,7 @@
           "segment_title": "Includes controlled substances",
           "segment_entries": [
             {
-              "entry_title": "Number of Prescriptions Written during reporting/ performance period (not controlled)",
+              "entry_title": "Number of Prescriptions Written During Reporting / Performance Period (not controlled)",
               "denom": true,
               "entry_values": [
                 {
@@ -386,7 +386,7 @@
               ]
             },
             {
-              "entry_title": "Number of Controlled Prescriptions Written during reporting/  performance period",
+              "entry_title": "Number of Controlled Prescriptions Written During Reporting / Performance Period ",
               "denom": true,
               "entry_values": [
                 {
@@ -514,7 +514,7 @@
           "segment_title": "Excludes controlled substances",
           "segment_entries": [
             {
-              "entry_title": "Number of Prescriptions Written during reporting/ performance period (not controlled)",
+              "entry_title": "Number of Prescriptions Written During Reporting / Performance Period (not controlled)",
               "denom": true,
               "entry_values": [
                 {

--- a/resources/RT1/EP_RT1_G1.json
+++ b/resources/RT1/EP_RT1_G1.json
@@ -24,7 +24,7 @@
   "test_data_notes": [
     "The set of calculations including controlled substances and the set of calculations excluding controlled substances are both required.  If a Health IT Module is not able to transmit controlled substances, it is at the discretion of the ONC-ATL to not test the controlled substance calculations.",
     "If a Health IT Module automatically transmits a prescription electronically when it is generated, it is at the discretion of the ATL not to test scenarios that assume this is not automatic.",
-    "If a Health IT Module automatically queries for a drug formulary upon every prescription that is generated, it is at the discretion of the ATL not to test scenarios that assume this is not automatic.",
+    "If a Health IT Module automatically queries for a drug formulary upon every prescription that is generated, it is at the discretion of the ATL not to test scenarios that assume this is not automatic. Additionally, the 2021 specification for MIPS has removed the requirement for formulary checking as part of the calculations.",
     "If a Health IT Module can only send changes electronically, it is at the discretion of the ATL not to test scenarios that assume a change could be sent via non-electronic means.  ",
     "The scenarios that test changed prescriptions assume that the original prescription was written electronically.",
     "Test data supply: ONC and Vendor-supplied. ONC provides the Test Data Scenarios and parameters; the Vendor will supply the Electronic Prescription entry and formulary details."

--- a/resources/RT1/EP_RT1_G2.json
+++ b/resources/RT1/EP_RT1_G2.json
@@ -28,7 +28,7 @@
   "test_data_notes": [
     "The set of calculations including controlled substances and the set of calculations excluding controlled substances are both required.  If a Health IT Module is not able to transmit controlled substances, it is at the discretion of the ONC-ATL to not test the controlled substance calculations.",
     "If a Health IT Module automatically transmits a prescription electronically when it is generated, it is at the discretion of the ONC-ATL not to test scenarios that assume this is not automatic.",
-    "If a Health IT Module automatically queries for a drug formulary upon every prescription that is generated, it is at the discretion of the ONC-ATL not to test scenarios that assume this is not automatic. Additionally, the 2021 specification for MIPS has removed the requirement for formulary checking as part of the calculations.",
+    "If a Health IT Module automatically queries for a drug formulary upon every prescription that is generated, it is at the discretion of the ONC-ATL not to test scenarios that assume this is not automatic. Additionally, the 2021 specification for MIPS has removed the requirement for formulary checking as part of the calculations (Select 'Hide - Automated Drug Queries' to remove this step from the test data).",
     "If a Health IT Module can only send changes electronically, it is at the discretion of the ONC-ATL not to test scenarios that assume a change could be sent via non-electronic means.  ",
     "The scenarios that test changed prescriptions assume that the original prescription was written electronically.",
     "Test data supply: ONC and Vendor-supplied. ONC provides the Test Data Scenarios and parameters; the Vendor will supply the Electronic Prescription entry and formulary details."

--- a/resources/RT1/EP_RT1_G2.json
+++ b/resources/RT1/EP_RT1_G2.json
@@ -28,7 +28,7 @@
   "test_data_notes": [
     "The set of calculations including controlled substances and the set of calculations excluding controlled substances are both required.  If a Health IT Module is not able to transmit controlled substances, it is at the discretion of the ONC-ATL to not test the controlled substance calculations.",
     "If a Health IT Module automatically transmits a prescription electronically when it is generated, it is at the discretion of the ONC-ATL not to test scenarios that assume this is not automatic.",
-    "If a Health IT Module automatically queries for a drug formulary upon every prescription that is generated, it is at the discretion of the ONC-ATL not to test scenarios that assume this is not automatic.",
+    "If a Health IT Module automatically queries for a drug formulary upon every prescription that is generated, it is at the discretion of the ONC-ATL not to test scenarios that assume this is not automatic. Additionally, the 2021 specification for MIPS has removed the requirement for formulary checking as part of the calculations.",
     "If a Health IT Module can only send changes electronically, it is at the discretion of the ONC-ATL not to test scenarios that assume a change could be sent via non-electronic means.  ",
     "The scenarios that test changed prescriptions assume that the original prescription was written electronically.",
     "Test data supply: ONC and Vendor-supplied. ONC provides the Test Data Scenarios and parameters; the Vendor will supply the Electronic Prescription entry and formulary details."

--- a/resources/RT1/EP_RT1_G2.json
+++ b/resources/RT1/EP_RT1_G2.json
@@ -104,7 +104,7 @@
           "segment_title": "Includes controlled substances",
           "segment_entries": [
             {
-              "entry_title": "Number of Prescriptions Written during reporting/ performance period (not controlled)",
+              "entry_title": "Number of Prescriptions Written During Reporting / Performance Period (not controlled)",
               "denom": true,
               "entry_values": [
                 {
@@ -215,7 +215,7 @@
               ]
             },
             {
-              "entry_title": "Number of Controlled Prescriptions Written during reporting/  performance period",
+              "entry_title": "Number of Controlled Prescriptions Written During Reporting / Performance Period ",
               "denom": true,
               "entry_values": [
                 {
@@ -1000,7 +1000,7 @@
           "segment_title": "Excludes controlled substances",
           "segment_entries": [
             {
-              "entry_title": "Number of Prescriptions Written during reporting/ performance period (not controlled)",
+              "entry_title": "Number of Prescriptions Written During Reporting / Performance Period (not controlled)",
               "denom": true,
               "entry_values": [
                 {
@@ -1797,7 +1797,7 @@
           "segment_title": "Includes controlled substances",
           "segment_entries": [
             {
-              "entry_title": "Number of Prescriptions Written during reporting/ performance period (not controlled)",
+              "entry_title": "Number of Prescriptions Written During Reporting / Performance Period (not controlled)",
               "denom": true,
               "entry_values": [
                 {
@@ -1887,7 +1887,7 @@
               ]
             },
             {
-              "entry_title": "Number of Controlled Prescriptions Written during reporting/  performance period",
+              "entry_title": "Number of Controlled Prescriptions Written During Reporting / Performance Period ",
               "denom": true,
               "entry_values": [
                 {
@@ -2535,7 +2535,7 @@
           "segment_title": "Excludes controlled substances",
           "segment_entries": [
             {
-              "entry_title": "Number of Prescriptions Written during reporting/ performance period (not controlled)",
+              "entry_title": "Number of Prescriptions Written During Reporting / Performance Period (not controlled)",
               "denom": true,
               "entry_values": [
                 {
@@ -3098,7 +3098,7 @@
           "segment_title": "Includes controlled substances",
           "segment_entries": [
             {
-              "entry_title": "Number of Prescriptions Written during reporting/ performance period (not controlled)",
+              "entry_title": "Number of Prescriptions Written During Reporting / Performance Period (not controlled)",
               "denom": true,
               "entry_values": [
                 {
@@ -3167,7 +3167,7 @@
               ]
             },
             {
-              "entry_title": "Number of Controlled Prescriptions Written during reporting/  performance period",
+              "entry_title": "Number of Controlled Prescriptions Written During Reporting / Performance Period ",
               "denom": true,
               "entry_values": [
                 {
@@ -3678,7 +3678,7 @@
           "segment_title": "Excludes controlled substances",
           "segment_entries": [
             {
-              "entry_title": "Number of Prescriptions Written during reporting/ performance period (not controlled)",
+              "entry_title": "Number of Prescriptions Written During Reporting / Performance Period (not controlled)",
               "denom": true,
               "entry_values": [
                 {

--- a/resources/RT10/EH_RT10_G1.json
+++ b/resources/RT10/EH_RT10_G1.json
@@ -26,7 +26,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Medication Orders Created Within or Outside Reporting Period",
+              "entry_title": "Medication Orders Created Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -157,7 +157,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Medication Orders Created Within or Outside Reporting Period",
+              "entry_title": "Medication Orders Created Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {

--- a/resources/RT10/EH_RT10_G2.json
+++ b/resources/RT10/EH_RT10_G2.json
@@ -27,7 +27,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Medication Orders Created Within or Outside Reporting Period",
+              "entry_title": "Medication Orders Created Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -165,7 +165,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Medication Orders Created Within or Outside Reporting Period",
+              "entry_title": "Medication Orders Created Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -273,7 +273,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Medication Orders Created Within or Outside Reporting Period",
+              "entry_title": "Medication Orders Created Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {

--- a/resources/RT10/EP_RT10_G1.json
+++ b/resources/RT10/EP_RT10_G1.json
@@ -26,7 +26,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Medication Orders Created Within or Outside Reporting Period",
+              "entry_title": "Medication Orders Created Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -157,7 +157,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Medication Orders Created Within or Outside Reporting Period",
+              "entry_title": "Medication Orders Created Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {

--- a/resources/RT10/EP_RT10_G2.json
+++ b/resources/RT10/EP_RT10_G2.json
@@ -27,7 +27,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Medication Orders Created Within or Outside Reporting Period",
+              "entry_title": "Medication Orders Created Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -165,7 +165,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Medication Orders Created Within or Outside Reporting Period",
+              "entry_title": "Medication Orders Created Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -273,7 +273,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Medication Orders Created Within or Outside Reporting Period",
+              "entry_title": "Medication Orders Created Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {

--- a/resources/RT11/EH_RT11_G1.json
+++ b/resources/RT11/EH_RT11_G1.json
@@ -26,7 +26,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Laboratory Orders Created Within or Outside Reporting Period",
+              "entry_title": "Laboratory Orders Created Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -157,7 +157,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Laboratory Orders Created Within or Outside Reporting Period",
+              "entry_title": "Laboratory Orders Created Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {

--- a/resources/RT11/EH_RT11_G2.json
+++ b/resources/RT11/EH_RT11_G2.json
@@ -27,7 +27,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Laboratory Orders Created Within or Outside Reporting Period",
+              "entry_title": "Laboratory Orders Created Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -165,7 +165,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Laboratory Orders Created Within or Outside Reporting Period",
+              "entry_title": "Laboratory Orders Created Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -273,7 +273,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Laboratory Orders Created Within or Outside Reporting Period",
+              "entry_title": "Laboratory Orders Created Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {

--- a/resources/RT11/EP_RT11_G1.json
+++ b/resources/RT11/EP_RT11_G1.json
@@ -26,7 +26,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Laboratory Orders Created Within or Outside Reporting Period",
+              "entry_title": "Laboratory Orders Created Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -157,7 +157,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Laboratory Orders Created Within or Outside Reporting Period",
+              "entry_title": "Laboratory Orders Created Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {

--- a/resources/RT11/EP_RT11_G2.json
+++ b/resources/RT11/EP_RT11_G2.json
@@ -27,7 +27,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Laboratory Orders Created Within or Outside Reporting Period",
+              "entry_title": "Laboratory Orders Created Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -165,7 +165,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Laboratory Orders Created Within or Outside Reporting Period",
+              "entry_title": "Laboratory Orders Created Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -273,7 +273,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Laboratory Orders Created Within or Outside Reporting Period",
+              "entry_title": "Laboratory Orders Created Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {

--- a/resources/RT12/EH_RT12_G1.json
+++ b/resources/RT12/EH_RT12_G1.json
@@ -27,7 +27,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Diagnostic Imaging Orders Created Within or Outside Reporting Period",
+              "entry_title": "Diagnostic Imaging Orders Created Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -158,7 +158,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Diagnostic Imaging Orders Created Within or Outside Reporting Period",
+              "entry_title": "Diagnostic Imaging Orders Created Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {

--- a/resources/RT12/EH_RT12_G2.json
+++ b/resources/RT12/EH_RT12_G2.json
@@ -27,7 +27,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Diagnostic Imaging Orders Created Within or Outside Reporting Period",
+              "entry_title": "Diagnostic Imaging Orders Created Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -165,7 +165,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Diagnostic Imaging Orders Created Within or Outside Reporting Period",
+              "entry_title": "Diagnostic Imaging Orders Created Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -273,7 +273,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Diagnostic Imaging Orders Created Within or Outside Reporting Period",
+              "entry_title": "Diagnostic Imaging Orders Created Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {

--- a/resources/RT12/EP_RT12_G1.json
+++ b/resources/RT12/EP_RT12_G1.json
@@ -26,7 +26,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Diagnostic Imaging Orders Created Within or Outside Reporting Period",
+              "entry_title": "Diagnostic Imaging Orders Created Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -157,7 +157,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Diagnostic Imaging Orders Created Within or Outside Reporting Period",
+              "entry_title": "Diagnostic Imaging Orders Created Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {

--- a/resources/RT12/EP_RT12_G2.json
+++ b/resources/RT12/EP_RT12_G2.json
@@ -27,7 +27,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Diagnostic Imaging Orders Created Within or Outside Reporting Period",
+              "entry_title": "Diagnostic Imaging Orders Created Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -165,7 +165,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Diagnostic Imaging Orders Created Within or Outside Reporting Period",
+              "entry_title": "Diagnostic Imaging Orders Created Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -273,7 +273,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Diagnostic Imaging Orders Created Within or Outside Reporting Period",
+              "entry_title": "Diagnostic Imaging Orders Created Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {

--- a/resources/RT15/EH_RT15_G1.json
+++ b/resources/RT15/EH_RT15_G1.json
@@ -34,23 +34,23 @@
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Allan Summers",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 }
               ]
             },
@@ -217,19 +217,19 @@
               "entry_values": [
                 {
                   "patient_id": "Anthony Edwards",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Bruce Hall",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Debra Steele",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Allan Summers",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 }
               ]
             },

--- a/resources/RT15/EH_RT15_G1.json
+++ b/resources/RT15/EH_RT15_G1.json
@@ -29,7 +29,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Admitted Within or Outside Reporting Period",
+              "entry_title": "Patient Admitted Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -212,7 +212,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Admitted Within or Outside Reporting Period",
+              "entry_title": "Patient Admitted Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {

--- a/resources/RT15/EH_RT15_G2.json
+++ b/resources/RT15/EH_RT15_G2.json
@@ -30,7 +30,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Admitted Within or Outside Reporting Period",
+              "entry_title": "Patient Admitted Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -220,7 +220,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Admitted Within or Outside Reporting Period",
+              "entry_title": "Patient Admitted Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -372,7 +372,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Admitted Within or Outside Reporting Period ",
+              "entry_title": "Patient Admitted Within Reporting Period ",
               "denom": true,
               "entry_values": [
                 {

--- a/resources/RT15/EH_RT15_G2.json
+++ b/resources/RT15/EH_RT15_G2.json
@@ -35,23 +35,23 @@
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Allan Summers",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 }
               ]
             },
@@ -225,19 +225,19 @@
               "entry_values": [
                 {
                   "patient_id": "Anthony Edwards",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Bruce Hall",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Debra Steele",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Allan Summers",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 }
               ]
             },
@@ -377,19 +377,19 @@
               "entry_values": [
                 {
                   "patient_id": "Debra Price",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Mark Gordon",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Gabriel Brady",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Kirk Patterson",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 }
               ]
             },

--- a/resources/RT2/EH_RT2a_G1.json
+++ b/resources/RT2/EH_RT2a_G1.json
@@ -42,28 +42,28 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting / Performance Period",
+              "entry_title": "Patient Discharged During Reporting / Performance Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Allan Summers",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -169,20 +169,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting / Performance Period",
+              "entry_title": "Patient Discharged During Reporting / Performance Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 }
               ]
             },
@@ -262,20 +262,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting / Performance Period",
+              "entry_title": "Patient Discharged During Reporting / Performance Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Anthony Edwards",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Bruce Hall",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Debra Steele",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -355,12 +355,12 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting / Performance Period",
+              "entry_title": "Patient Discharged During Reporting / Performance Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 }
               ]
             },

--- a/resources/RT2/EH_RT2a_G2.json
+++ b/resources/RT2/EH_RT2a_G2.json
@@ -44,28 +44,28 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting / Performance Period",
+              "entry_title": "Patient Discharged During Reporting / Performance Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Allan Summers",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -177,20 +177,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting / Performance Period",
+              "entry_title": "Patient Discharged During Reporting / Performance Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 }
               ]
             },
@@ -274,20 +274,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting / Performance Period",
+              "entry_title": "Patient Discharged During Reporting / Performance Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Anthony Edwards",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Bruce Hall",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Debra Steele",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -371,23 +371,23 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "entry_values": [
                 {
                   "patient_id": "Debra Price",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Mark Gordon",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Gabriel Brady",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Kirk Patterson",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -485,12 +485,12 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting / Performance Period",
+              "entry_title": "Patient Discharged During Reporting / Performance Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 }
               ]
             },

--- a/resources/RT2/EH_RT2a_G2.json
+++ b/resources/RT2/EH_RT2a_G2.json
@@ -371,7 +371,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During Reporting Period",
+              "entry_title": "Patient Discharged During Reporting / Performance Period",
               "entry_values": [
                 {
                   "patient_id": "Debra Price",

--- a/resources/RT2/EH_RT2b_G1.json
+++ b/resources/RT2/EH_RT2b_G1.json
@@ -42,28 +42,28 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting / Performance Period",
+              "entry_title": "Patient Discharged During Reporting / Performance Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Allan Summers",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -142,20 +142,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting / Performance Period",
+              "entry_title": "Patient Discharged During Reporting / Performance Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 }
               ]
             },
@@ -216,20 +216,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting / Performance Period",
+              "entry_title": "Patient Discharged During Reporting / Performance Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Anthony Edwards",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Bruce Hall",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Debra Steele",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -290,12 +290,12 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting / Performance Period",
+              "entry_title": "Patient Discharged During Reporting / Performance Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 }
               ]
             },

--- a/resources/RT2/EH_RT2b_G2.json
+++ b/resources/RT2/EH_RT2b_G2.json
@@ -44,28 +44,28 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting / Performance Period",
+              "entry_title": "Patient Discharged During Reporting / Performance Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Allan Summers",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -150,20 +150,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting / Performance Period",
+              "entry_title": "Patient Discharged During Reporting / Performance Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 }
               ]
             },
@@ -228,20 +228,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting / Performance Period",
+              "entry_title": "Patient Discharged During Reporting / Performance Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Anthony Edwards",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Bruce Hall",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Debra Steele",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -306,23 +306,23 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "entry_values": [
                 {
                   "patient_id": "Debra Price",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Mark Gordon",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Gabriel Brady",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Kirk Patterson",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -397,12 +397,12 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting / Performance Period",
+              "entry_title": "Patient Discharged During Reporting / Performance Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 }
               ]
             },

--- a/resources/RT2/EH_RT2b_G2.json
+++ b/resources/RT2/EH_RT2b_G2.json
@@ -306,7 +306,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During Reporting Period",
+              "entry_title": "Patient Discharged During Reporting / Performance Period",
               "entry_values": [
                 {
                   "patient_id": "Debra Price",

--- a/resources/RT2/EH_RT2c_G1.json
+++ b/resources/RT2/EH_RT2c_G1.json
@@ -42,28 +42,28 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting / Performance Period",
+              "entry_title": "Patient Discharged During Reporting / Performance Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Allan Summers",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -142,20 +142,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting / Performance Period",
+              "entry_title": "Patient Discharged During Reporting / Performance Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 }
               ]
             },
@@ -216,20 +216,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting / Performance Period",
+              "entry_title": "Patient Discharged During Reporting / Performance Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Anthony Edwards",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Bruce Hall",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Debra Steele",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -290,12 +290,12 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting / Performance Period",
+              "entry_title": "Patient Discharged During Reporting / Performance Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 }
               ]
             },

--- a/resources/RT2/EH_RT2c_G2.json
+++ b/resources/RT2/EH_RT2c_G2.json
@@ -44,28 +44,28 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting / Performance Period",
+              "entry_title": "Patient Discharged During Reporting / Performance Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Allan Summers",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -150,20 +150,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting / Performance Period",
+              "entry_title": "Patient Discharged During Reporting / Performance Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 }
               ]
             },
@@ -228,20 +228,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting / Performance Period",
+              "entry_title": "Patient Discharged During Reporting / Performance Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Anthony Edwards",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Bruce Hall",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Debra Steele",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -306,23 +306,23 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "entry_values": [
                 {
                   "patient_id": "Debra Price",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Mark Gordon",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Gabriel Brady",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Kirk Patterson",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -397,12 +397,12 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting / Performance Period",
+              "entry_title": "Patient Discharged During Reporting / Performance Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 }
               ]
             },

--- a/resources/RT2/EH_RT2c_G2.json
+++ b/resources/RT2/EH_RT2c_G2.json
@@ -306,7 +306,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During Reporting Period",
+              "entry_title": "Patient Discharged During Reporting / Performance Period",
               "entry_values": [
                 {
                   "patient_id": "Debra Price",

--- a/resources/RT2/EP_RT2a_G1.json
+++ b/resources/RT2/EP_RT2a_G1.json
@@ -41,28 +41,28 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen  During or Outside EHR Reporting Period",
+              "entry_title": "Patient Seen During EHR Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Lavon Earle",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Trula Covey",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Mai Nguyen",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Tom Warner",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Elsa Wu",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 }
               ]
             },
@@ -180,20 +180,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen  During or Outside EHR Reporting Period",
+              "entry_title": "Patient Seen During EHR Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Alan Bench",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Rashida Champagne",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "David Brown",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 }
               ]
             },
@@ -273,12 +273,12 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen  During or Outside EHR Reporting Period",
+              "entry_title": "Patient Seen During EHR Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Elsa Wu",
-                  "entry_value": "Second encounter, during"
+                  "entry_value": "Second encounter"
                 }
               ]
             },

--- a/resources/RT2/EP_RT2a_G2.json
+++ b/resources/RT2/EP_RT2a_G2.json
@@ -105,7 +105,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen  During or Outside EHR Reporting Period",
+              "entry_title": "Patient Seen During EHR Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -113,19 +113,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -134,19 +134,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -155,19 +155,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -176,7 +176,7 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
@@ -188,7 +188,7 @@
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -197,19 +197,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 }
@@ -783,7 +783,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen  During or Outside EHR Reporting Period",
+              "entry_title": "Patient Seen During EHR Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -791,19 +791,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     }
                   ]
                 },
@@ -812,19 +812,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     }
                   ]
                 },
@@ -833,19 +833,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     }
                   ]
                 }
@@ -1229,7 +1229,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen  During or Outside EHR Reporting Period",
+              "entry_title": "Patient Seen During EHR Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -1237,19 +1237,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -1258,19 +1258,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -1279,19 +1279,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 }
@@ -1675,7 +1675,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen  During or Outside EHR Reporting Period",
+              "entry_title": "Patient Seen During EHR Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -1683,19 +1683,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -1704,19 +1704,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -1725,19 +1725,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 }
@@ -2121,7 +2121,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen  During or Outside EHR Reporting Period",
+              "entry_title": "Patient Seen During EHR Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -2129,7 +2129,7 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
@@ -2141,7 +2141,7 @@
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     }
                   ]
                 }

--- a/resources/RT2/EP_RT2b_G1.json
+++ b/resources/RT2/EP_RT2b_G1.json
@@ -41,28 +41,28 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen  During or Outside EHR Reporting Period",
+              "entry_title": "Patient Seen During EHR Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Lavon Earle",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Trula Covey",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Mai Nguyen",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Tom Warner",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Elsa Wu",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 }
               ]
             },
@@ -153,20 +153,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen  During or Outside EHR Reporting Period",
+              "entry_title": "Patient Seen During EHR Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Alan Bench",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Rashida Champagne",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "David Brown",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 }
               ]
             },
@@ -227,12 +227,12 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen  During or Outside EHR Reporting Period",
+              "entry_title": "Patient Seen During EHR Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Elsa Wu",
-                  "entry_value": "Second encounter, during"
+                  "entry_value": "Second encounter"
                 }
               ]
             },

--- a/resources/RT2/EP_RT2b_G2.json
+++ b/resources/RT2/EP_RT2b_G2.json
@@ -103,7 +103,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen  During or Outside EHR Reporting Period",
+              "entry_title": "Patient Seen During EHR Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -111,19 +111,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -132,19 +132,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -153,19 +153,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -174,7 +174,7 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
@@ -186,7 +186,7 @@
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -195,19 +195,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 }
@@ -669,7 +669,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen  During or Outside EHR Reporting Period",
+              "entry_title": "Patient Seen During EHR Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -677,19 +677,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     }
                   ]
                 },
@@ -698,19 +698,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     }
                   ]
                 },
@@ -719,19 +719,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     }
                   ]
                 }
@@ -1045,7 +1045,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen  During or Outside EHR Reporting Period",
+              "entry_title": "Patient Seen During EHR Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -1053,19 +1053,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -1074,19 +1074,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -1095,19 +1095,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 }
@@ -1420,7 +1420,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen  During or Outside EHR Reporting Period",
+              "entry_title": "Patient Seen During EHR Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -1428,19 +1428,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -1449,19 +1449,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -1470,19 +1470,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 }
@@ -1796,7 +1796,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen  During or Outside EHR Reporting Period",
+              "entry_title": "Patient Seen During EHR Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -1804,7 +1804,7 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
@@ -1816,7 +1816,7 @@
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     }
                   ]
                 }

--- a/resources/RT2/EP_RT2c_G1.json
+++ b/resources/RT2/EP_RT2c_G1.json
@@ -41,28 +41,28 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen  During or Outside EHR Reporting Period",
+              "entry_title": "Patient Seen During EHR Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Lavon Earle",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Trula Covey",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Mai Nguyen",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Tom Warner",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Elsa Wu",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 }
               ]
             },
@@ -153,20 +153,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen  During or Outside EHR Reporting Period",
+              "entry_title": "Patient Seen During EHR Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Alan Bench",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Rashida Champagne",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "David Brown",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 }
               ]
             },
@@ -227,12 +227,12 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen  During or Outside EHR Reporting Period",
+              "entry_title": "Patient Seen During EHR Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Elsa Wu",
-                  "entry_value": "Second encounter, during"
+                  "entry_value": "Second encounter"
                 }
               ]
             },

--- a/resources/RT2/EP_RT2c_G2.json
+++ b/resources/RT2/EP_RT2c_G2.json
@@ -104,7 +104,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen  During or Outside EHR Reporting Period",
+              "entry_title": "Patient Seen During EHR Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -112,19 +112,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -133,19 +133,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -154,19 +154,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -175,7 +175,7 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
@@ -187,7 +187,7 @@
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -196,19 +196,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 }
@@ -670,7 +670,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen  During or Outside EHR Reporting Period",
+              "entry_title": "Patient Seen During EHR Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -678,19 +678,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     }
                   ]
                 },
@@ -699,19 +699,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     }
                   ]
                 },
@@ -720,19 +720,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     }
                   ]
                 }
@@ -1046,7 +1046,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen  During or Outside EHR Reporting Period",
+              "entry_title": "Patient Seen During EHR Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -1054,19 +1054,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -1075,19 +1075,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -1096,19 +1096,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 }
@@ -1422,7 +1422,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen  During or Outside EHR Reporting Period",
+              "entry_title": "Patient Seen During EHR Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -1430,19 +1430,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -1451,19 +1451,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -1472,19 +1472,19 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN A/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 }
@@ -1798,7 +1798,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen  During or Outside EHR Reporting Period",
+              "entry_title": "Patient Seen During EHR Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -1806,7 +1806,7 @@
                   "providers": [
                     {
                       "provider": "TIN A/Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "TIN B/Provider 1",
@@ -1818,7 +1818,7 @@
                     },
                     {
                       "provider": "TIN B/Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     }
                   ]
                 }

--- a/resources/RT3/EH_RT3_G1.json
+++ b/resources/RT3/EH_RT3_G1.json
@@ -32,28 +32,28 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Allan Summers",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -158,20 +158,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 }
               ]
             },
@@ -250,20 +250,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Anthony Edwards",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Bruce Hall",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Debra Steele",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -342,12 +342,12 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 }
               ]
             },

--- a/resources/RT3/EH_RT3_G2.json
+++ b/resources/RT3/EH_RT3_G2.json
@@ -33,28 +33,28 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Allan Summers",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -165,20 +165,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 }
               ]
             },
@@ -261,20 +261,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Anthony Edwards",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Bruce Hall",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Debra Steele",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -357,23 +357,23 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "entry_values": [
                 {
                   "patient_id": "Debra Price",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Mark Gordon",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Gabriel Brady",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Kirk Patterson",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -470,12 +470,12 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 }
               ]
             },

--- a/resources/RT3/EP_RT3_G1.json
+++ b/resources/RT3/EP_RT3_G1.json
@@ -33,33 +33,33 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen During or Outside of Reporting / Performance Period",
+              "entry_title": "Patient Seen During Reporting / Performance Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Lavon Earle",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Trula Covey",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Mai Nguyen",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Tom Warner",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Elsa Wu",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 }
               ]
             },
             {
-              "entry_title": "CEHRT Identifies Patient-Specific Education Resources  During or Outside Reporting/Performance Period",
+              "entry_title": "CEHRT Identifies Patient-Specific Education Resources  During Reporting/Performance Period",
               "numer": true,
               "entry_values": [
                 {
@@ -85,7 +85,7 @@
               ]
             },
             {
-              "entry_title": "EP/EC Provides Electronic Access to Patient-Specific Educational Resources Identified by CEHRT During or Outside Reporting/Performance Period",
+              "entry_title": "EP/EC Provides Electronic Access to Patient-Specific Educational Resources Identified by CEHRT During Reporting/Performance Period",
               "numer": true,
               "automatable_step": { "title": "Steps that assume education material availablity is not automatic" },
               "entry_values": [
@@ -171,25 +171,25 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen During or Outside of Reporting / Performance Period",
+              "entry_title": "Patient Seen During Reporting / Performance Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Alan Bench",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Rashida Champagne",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "David Brown",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 }
               ]
             },
             {
-              "entry_title": "CEHRT Identifies Patient-Specific Education Resources  During or Outside Reporting/Performance Period",
+              "entry_title": "CEHRT Identifies Patient-Specific Education Resources  During Reporting/Performance Period",
               "numer": true,
               "entry_values": [
                 {
@@ -207,7 +207,7 @@
               ]
             },
             {
-              "entry_title": "EP/EC Provides Electronic Access to Patient-Specific Educational Resources Identified by CEHRT During or Outside Reporting/Performance Period",
+              "entry_title": "EP/EC Provides Electronic Access to Patient-Specific Educational Resources Identified by CEHRT During Reporting/Performance Period",
               "numer": true,
               "automatable_step": { "title": "Steps that assume education material availablity is not automatic" },
               "entry_values": [
@@ -263,17 +263,17 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen During or Outside of Reporting / Performance Period",
+              "entry_title": "Patient Seen During Reporting / Performance Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Elsa Wu",
-                  "entry_value": "Second encounter, during"
+                  "entry_value": "Second encounter"
                 }
               ]
             },
             {
-              "entry_title": "CEHRT Identifies Patient-Specific Education Resources  During or Outside Reporting/Performance Period",
+              "entry_title": "CEHRT Identifies Patient-Specific Education Resources  During Reporting/Performance Period",
               "numer": true,
               "entry_values": [
                 {
@@ -283,7 +283,7 @@
               ]
             },
             {
-              "entry_title": "EP/EC Provides Electronic Access to Patient-Specific Educational Resources Identified by CEHRT During or Outside Reporting/Performance Period",
+              "entry_title": "EP/EC Provides Electronic Access to Patient-Specific Educational Resources Identified by CEHRT During Reporting/Performance Period",
               "numer": true,
               "automatable_step": { "title": "Steps that assume education material availablity is not automatic" },
               "entry_values": [

--- a/resources/RT3/EP_RT3_G2.json
+++ b/resources/RT3/EP_RT3_G2.json
@@ -47,7 +47,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen During or Outside of Reporting / Performance Period",
+              "entry_title": "Patient Seen During Reporting / Performance Period",
               "denom": true,
               "entry_values": [
                 {
@@ -55,11 +55,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -68,11 +68,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -81,11 +81,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -94,7 +94,7 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
@@ -107,11 +107,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 }
@@ -380,7 +380,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen During or Outside of Reporting / Performance Period",
+              "entry_title": "Patient Seen During Reporting / Performance Period",
               "denom": true,
               "entry_values": [
                 {
@@ -388,11 +388,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     }
                   ]
                 },
@@ -401,11 +401,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     }
                   ]
                 },
@@ -414,11 +414,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     }
                   ]
                 }
@@ -601,7 +601,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen During or Outside of Reporting / Performance Period",
+              "entry_title": "Patient Seen During Reporting / Performance Period",
               "denom": true,
               "entry_values": [
                 {
@@ -609,11 +609,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -622,11 +622,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -635,11 +635,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 }
@@ -822,7 +822,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen During or Outside of Reporting / Performance Period",
+              "entry_title": "Patient Seen During Reporting / Performance Period",
               "denom": true,
               "entry_values": [
                 {
@@ -830,11 +830,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -843,11 +843,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -856,11 +856,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 }
@@ -1043,7 +1043,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen During or Outside of Reporting / Performance Period",
+              "entry_title": "Patient Seen During Reporting / Performance Period",
               "denom": true,
               "entry_values": [
                 {
@@ -1051,7 +1051,7 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "Provider 2",

--- a/resources/RT4/EH_RT4a_G1.json
+++ b/resources/RT4/EH_RT4a_G1.json
@@ -31,28 +31,28 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Allan Summers",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -150,20 +150,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 }
               ]
             },
@@ -237,20 +237,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Anthony Edwards",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Bruce Hall",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Debra Steele",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -324,12 +324,12 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 }
               ]
             },

--- a/resources/RT4/EH_RT4a_G2.json
+++ b/resources/RT4/EH_RT4a_G2.json
@@ -32,28 +32,28 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Allan Summers",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -157,20 +157,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 }
               ]
             },
@@ -248,20 +248,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Anthony Edwards",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Bruce Hall",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Debra Steele",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -339,23 +339,23 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside Reporting Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "entry_values": [
                 {
                   "patient_id": "Debra Price",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Mark Gordon",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Gabriel Brady",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Kirk Patterson",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -446,12 +446,12 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 }
               ]
             },

--- a/resources/RT4/EH_RT4b_G1.json
+++ b/resources/RT4/EH_RT4b_G1.json
@@ -31,28 +31,28 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Allan Summers",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -124,20 +124,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 }
               ]
             },
@@ -193,20 +193,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Anthony Edwards",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Bruce Hall",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Debra Steele",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -262,12 +262,12 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 }
               ]
             },

--- a/resources/RT4/EH_RT4b_G2.json
+++ b/resources/RT4/EH_RT4b_G2.json
@@ -32,28 +32,28 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Allan Summers",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -131,20 +131,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 }
               ]
             },
@@ -204,20 +204,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Anthony Edwards",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Bruce Hall",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Debra Steele",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -277,23 +277,23 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside Reporting Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "entry_values": [
                 {
                   "patient_id": "Debra Price",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Mark Gordon",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Gabriel Brady",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Kirk Patterson",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -362,12 +362,12 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 }
               ]
             },

--- a/resources/RT4/EH_RT4c_G1.json
+++ b/resources/RT4/EH_RT4c_G1.json
@@ -31,28 +31,28 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Allan Summers",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -124,20 +124,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 }
               ]
             },
@@ -193,20 +193,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Anthony Edwards",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Bruce Hall",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Debra Steele",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -262,12 +262,12 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 }
               ]
             },

--- a/resources/RT4/EH_RT4c_G2.json
+++ b/resources/RT4/EH_RT4c_G2.json
@@ -32,28 +32,28 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Allan Summers",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -131,20 +131,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 }
               ]
             },
@@ -204,20 +204,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Anthony Edwards",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Bruce Hall",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Debra Steele",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -277,23 +277,23 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside Reporting Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "entry_values": [
                 {
                   "patient_id": "Debra Price",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Mark Gordon",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Gabriel Brady",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Kirk Patterson",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -362,12 +362,12 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 }
               ]
             },

--- a/resources/RT4/EP_RT4a_G1.json
+++ b/resources/RT4/EP_RT4a_G1.json
@@ -32,28 +32,28 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen During or Outside Reporting Period ",
+              "entry_title": "Patient Seen During Reporting Period ",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Lavon Earle",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Trula Covey",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Mai Nguyen",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Tom Warner",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Elsa Wu",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 }
               ]
             },
@@ -151,20 +151,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen During or Outside Reporting Period ",
+              "entry_title": "Patient Seen During Reporting Period ",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Trula Covey",
-                  "entry_value": "Second encounter, during"
+                  "entry_value": "Second encounter"
                 },
                 {
                   "patient_id": "Lavon Earle",
-                  "entry_value": "Second encounter, during"
+                  "entry_value": "Second encounter"
                 },
                 {
                   "patient_id": "Mai Nguyen",
-                  "entry_value": "Second encounter, during"
+                  "entry_value": "Second encounter"
                 }
               ]
             },
@@ -238,20 +238,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen During or Outside Reporting Period ",
+              "entry_title": "Patient Seen During Reporting Period ",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Alan Bench",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Rashida Champagne",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "David Brown",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 }
               ]
             },
@@ -325,12 +325,12 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen During or Outside Reporting Period ",
+              "entry_title": "Patient Seen During Reporting Period ",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Elsa Wu",
-                  "entry_value": "Second encounter, during"
+                  "entry_value": "Second encounter"
                 }
               ]
             },

--- a/resources/RT4/EP_RT4a_G2.json
+++ b/resources/RT4/EP_RT4a_G2.json
@@ -43,7 +43,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen During or Outside Reporting Period ",
+              "entry_title": "Patient Seen During Reporting Period ",
               "denom": true,
               "entry_values": [
                 {
@@ -51,11 +51,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -64,11 +64,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -77,11 +77,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -90,7 +90,7 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
@@ -103,11 +103,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 }
@@ -363,7 +363,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen During or Outside Reporting Period ",
+              "entry_title": "Patient Seen During Reporting Period ",
               "denom": true,
               "entry_values": [
                 {
@@ -371,11 +371,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     }
                   ]
                 },
@@ -384,11 +384,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     }
                   ]
                 },
@@ -397,11 +397,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     }
                   ]
                 }
@@ -575,7 +575,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen During or Outside Reporting Period ",
+              "entry_title": "Patient Seen During Reporting Period ",
               "denom": true,
               "entry_values": [
                 {
@@ -583,11 +583,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -596,11 +596,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -609,11 +609,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 }
@@ -787,7 +787,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen During or Outside Reporting Period ",
+              "entry_title": "Patient Seen During Reporting Period ",
               "denom": true,
               "entry_values": [
                 {
@@ -795,11 +795,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -808,11 +808,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -821,11 +821,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 }
@@ -999,7 +999,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen During or Outside Reporting Period ",
+              "entry_title": "Patient Seen During Reporting Period ",
               "denom": true,
               "entry_values": [
                 {
@@ -1007,7 +1007,7 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "Provider 2",

--- a/resources/RT4/EP_RT4b_G1.json
+++ b/resources/RT4/EP_RT4b_G1.json
@@ -31,28 +31,28 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen During or Outside Reporting Period ",
+              "entry_title": "Patient Seen During Reporting Period ",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Lavon Earle",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Trula Covey",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Mai Nguyen",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Tom Warner",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Elsa Wu",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 }
               ]
             },
@@ -124,20 +124,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen During or Outside Reporting Period ",
+              "entry_title": "Patient Seen During Reporting Period ",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Trula Covey",
-                  "entry_value": "Second encounter, during"
+                  "entry_value": "Second encounter"
                 },
                 {
                   "patient_id": "Lavon Earle",
-                  "entry_value": "Second encounter, during"
+                  "entry_value": "Second encounter"
                 },
                 {
                   "patient_id": "Mai Nguyen",
-                  "entry_value": "Second encounter, during"
+                  "entry_value": "Second encounter"
                 }
               ]
             },
@@ -193,20 +193,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen During or Outside Reporting Period ",
+              "entry_title": "Patient Seen During Reporting Period ",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Alan Bench",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Rashida Champagne",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "David Brown",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 }
               ]
             },
@@ -262,12 +262,12 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen During or Outside Reporting Period ",
+              "entry_title": "Patient Seen During Reporting Period ",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Elsa Wu",
-                  "entry_value": "Second encounter, during"
+                  "entry_value": "Second encounter"
                 }
               ]
             },

--- a/resources/RT4/EP_RT4b_G2.json
+++ b/resources/RT4/EP_RT4b_G2.json
@@ -43,7 +43,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen During or Outside Reporting Period ",
+              "entry_title": "Patient Seen During Reporting Period ",
               "denom": true,
               "entry_values": [
                 {
@@ -51,11 +51,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -64,11 +64,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -77,11 +77,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -90,7 +90,7 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
@@ -103,11 +103,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 }
@@ -292,7 +292,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen During or Outside Reporting Period ",
+              "entry_title": "Patient Seen During Reporting Period ",
               "denom": true,
               "entry_values": [
                 {
@@ -300,11 +300,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     }
                   ]
                 },
@@ -313,11 +313,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     }
                   ]
                 },
@@ -326,11 +326,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     }
                   ]
                 }
@@ -459,7 +459,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen During or Outside Reporting Period ",
+              "entry_title": "Patient Seen During Reporting Period ",
               "denom": true,
               "entry_values": [
                 {
@@ -467,11 +467,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -480,11 +480,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -493,11 +493,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 }
@@ -626,7 +626,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen During or Outside Reporting Period ",
+              "entry_title": "Patient Seen During Reporting Period ",
               "denom": true,
               "entry_values": [
                 {
@@ -634,11 +634,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -647,11 +647,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -660,11 +660,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 }
@@ -793,7 +793,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen During or Outside Reporting Period ",
+              "entry_title": "Patient Seen During Reporting Period ",
               "denom": true,
               "entry_values": [
                 {
@@ -801,7 +801,7 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "Provider 2",

--- a/resources/RT4/EP_RT4c_G1.json
+++ b/resources/RT4/EP_RT4c_G1.json
@@ -32,28 +32,28 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen During or Outside Reporting Period ",
+              "entry_title": "Patient Seen During Reporting Period ",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Lavon Earle",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Trula Covey",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Mai Nguyen",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Tom Warner",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Elsa Wu",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 }
               ]
             },
@@ -125,20 +125,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen During or Outside Reporting Period ",
+              "entry_title": "Patient Seen During Reporting Period ",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Trula Covey",
-                  "entry_value": "Second encounter, during"
+                  "entry_value": "Second encounter"
                 },
                 {
                   "patient_id": "Lavon Earle",
-                  "entry_value": "Second encounter, during"
+                  "entry_value": "Second encounter"
                 },
                 {
                   "patient_id": "Mai Nguyen",
-                  "entry_value": "Second encounter, during"
+                  "entry_value": "Second encounter"
                 }
               ]
             },
@@ -194,20 +194,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen During or Outside Reporting Period ",
+              "entry_title": "Patient Seen During Reporting Period ",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Alan Bench",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Rashida Champagne",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "David Brown",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 }
               ]
             },
@@ -263,12 +263,12 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen During or Outside Reporting Period ",
+              "entry_title": "Patient Seen During Reporting Period ",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Elsa Wu",
-                  "entry_value": "Second encounter, during"
+                  "entry_value": "Second encounter"
                 }
               ]
             },

--- a/resources/RT4/EP_RT4c_G2.json
+++ b/resources/RT4/EP_RT4c_G2.json
@@ -43,7 +43,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen During or Outside Reporting Period ",
+              "entry_title": "Patient Seen During Reporting Period ",
               "denom": true,
               "entry_values": [
                 {
@@ -51,11 +51,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -64,11 +64,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -77,11 +77,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -90,7 +90,7 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
@@ -103,11 +103,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 }
@@ -292,7 +292,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen During or Outside Reporting Period ",
+              "entry_title": "Patient Seen During Reporting Period ",
               "denom": true,
               "entry_values": [
                 {
@@ -300,11 +300,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     }
                   ]
                 },
@@ -313,11 +313,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     }
                   ]
                 },
@@ -326,11 +326,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     }
                   ]
                 }
@@ -459,7 +459,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen During or Outside Reporting Period ",
+              "entry_title": "Patient Seen During Reporting Period ",
               "denom": true,
               "entry_values": [
                 {
@@ -467,11 +467,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -480,11 +480,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -493,11 +493,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 }
@@ -626,7 +626,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen During or Outside Reporting Period ",
+              "entry_title": "Patient Seen During Reporting Period ",
               "denom": true,
               "entry_values": [
                 {
@@ -634,11 +634,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -647,11 +647,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -660,11 +660,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 }
@@ -793,7 +793,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen During or Outside Reporting Period ",
+              "entry_title": "Patient Seen During Reporting Period ",
               "denom": true,
               "entry_values": [
                 {
@@ -801,7 +801,7 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "Provider 2",

--- a/resources/RT5/EH_RT5_G1.json
+++ b/resources/RT5/EH_RT5_G1.json
@@ -34,28 +34,28 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Allan Summers",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -212,20 +212,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 }
               ]
             },
@@ -340,20 +340,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Anthony Edwards",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Bruce Hall",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Debra Steele",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -468,12 +468,12 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 }
               ]
             },

--- a/resources/RT5/EH_RT5_G2.json
+++ b/resources/RT5/EH_RT5_G2.json
@@ -36,28 +36,28 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Allan Summers",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -220,20 +220,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 }
               ]
             },
@@ -352,20 +352,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Anthony Edwards",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Bruce Hall",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Debra Steele",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -484,23 +484,23 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside Reporting Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "entry_values": [
                 {
                   "patient_id": "Debra Price",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Mark Gordon",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Gabriel Brady",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Kirk Patterson",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -641,12 +641,12 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged During or Outside of Reporting  Period",
+              "entry_title": "Patient Discharged During Reporting Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 }
               ]
             },

--- a/resources/RT5/EP_RT5_G1.json
+++ b/resources/RT5/EP_RT5_G1.json
@@ -34,28 +34,28 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen  During or Outside Reporting/Performance Period",
+              "entry_title": "Patient Seen During Reporting/Performance Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Lavon Earle",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Trula Covey",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Mai Nguyen",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Tom Warner",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Elsa Wu",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 }
               ]
             },
@@ -212,20 +212,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen  During or Outside Reporting/Performance Period",
+              "entry_title": "Patient Seen During Reporting/Performance Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Trula Covey",
-                  "entry_value": "Second encounter, during"
+                  "entry_value": "Second encounter"
                 },
                 {
                   "patient_id": "Lavon Earle",
-                  "entry_value": "Second encounter, during"
+                  "entry_value": "Second encounter"
                 },
                 {
                   "patient_id": "Mai Nguyen",
-                  "entry_value": "Second encounter, during"
+                  "entry_value": "Second encounter"
                 }
               ]
             },
@@ -330,7 +330,7 @@
     },
     {
       "scenario_title": "Scenario 3",
-      "scenario_description": "Patient Seen  During or Outside Reporting/Performance Period",
+      "scenario_description": "Patient Seen During Reporting/Performance Period",
       "segments": [
         {
           "segment_total":
@@ -340,19 +340,19 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen During or Outside Reporting Period ",
+              "entry_title": "Patient Seen During Reporting Period ",
               "entry_values": [
                 {
                   "patient_id": "Alan Bench",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Rashida Champagne",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "David Brown",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 }
               ]
             },
@@ -467,12 +467,12 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen  During or Outside Reporting/Performance Period",
+              "entry_title": "Patient Seen During Reporting/Performance Period",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Elsa Wu",
-                  "entry_value": "Second encounter, during"
+                  "entry_value": "Second encounter"
                 }
               ]
             },

--- a/resources/RT5/EP_RT5_G1.json
+++ b/resources/RT5/EP_RT5_G1.json
@@ -340,7 +340,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen During Reporting Period ",
+              "entry_title": "Patient Seen During Reporting/Performance Period ",
               "entry_values": [
                 {
                   "patient_id": "Alan Bench",

--- a/resources/RT5/EP_RT5_G2.json
+++ b/resources/RT5/EP_RT5_G2.json
@@ -48,7 +48,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen  During or Outside Reporting/Performance Period",
+              "entry_title": "Patient Seen During Reporting/Performance Period",
               "denom": true,
               "entry_values": [
                 {
@@ -56,11 +56,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -69,11 +69,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -82,11 +82,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -95,7 +95,7 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
@@ -108,11 +108,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 }
@@ -523,7 +523,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen  During or Outside Reporting/Performance Period",
+              "entry_title": "Patient Seen During Reporting/Performance Period",
               "denom": true,
               "entry_values": [
                 {
@@ -531,11 +531,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     }
                   ]
                 },
@@ -544,11 +544,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     }
                   ]
                 },
@@ -557,11 +557,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     }
                   ]
                 }
@@ -834,7 +834,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen  During or Outside Reporting/Performance Period",
+              "entry_title": "Patient Seen During Reporting/Performance Period",
               "denom": true,
               "entry_values": [
                 {
@@ -842,11 +842,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -855,11 +855,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -868,11 +868,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 }
@@ -1145,7 +1145,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen  During or Outside Reporting/Performance Period",
+              "entry_title": "Patient Seen During Reporting/Performance Period",
               "denom": true,
               "entry_values": [
                 {
@@ -1153,11 +1153,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -1166,11 +1166,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -1179,11 +1179,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 }
@@ -1456,7 +1456,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen  During or Outside Reporting/Performance Period",
+              "entry_title": "Patient Seen During Reporting/Performance Period",
               "denom": true,
               "entry_values": [
                 {
@@ -1464,7 +1464,7 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "Provider 2",

--- a/resources/RT6/EH_RT6_G1.json
+++ b/resources/RT6/EH_RT6_G1.json
@@ -28,28 +28,28 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged Within or Outside ReportingPeriod ",
+              "entry_title": "Patient Discharged Within Reporting Period ",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Allan Summers",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -121,20 +121,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged Within or Outside ReportingPeriod ",
+              "entry_title": "Patient Discharged Within Reporting Period ",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 }
               ]
             },
@@ -190,20 +190,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged Within or Outside ReportingPeriod ",
+              "entry_title": "Patient Discharged Within Reporting Period ",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Anthony Edwards",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Bruce Hall",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Debra Steele",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -259,12 +259,12 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged Within or Outside ReportingPeriod ",
+              "entry_title": "Patient Discharged Within Reporting Period ",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 }
               ]
             },

--- a/resources/RT6/EH_RT6_G2.json
+++ b/resources/RT6/EH_RT6_G2.json
@@ -30,28 +30,28 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged Within or Outside ReportingPeriod ",
+              "entry_title": "Patient Discharged Within Reporting Period ",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Allan Summers",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -129,20 +129,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged Within or Outside ReportingPeriod ",
+              "entry_title": "Patient Discharged Within Reporting Period ",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 }
               ]
             },
@@ -202,20 +202,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged Within or Outside ReportingPeriod ",
+              "entry_title": "Patient Discharged Within Reporting Period ",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Anthony Edwards",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Bruce Hall",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Debra Steele",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -275,23 +275,23 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged Within or Outside Reporting Period",
+              "entry_title": "Patient Discharged Within Reporting Period",
               "entry_values": [
                 {
                   "patient_id": "Debra Price",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Mark Gordon",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Gabriel Brady",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 },
                 {
                   "patient_id": "Kirk Patterson",
-                  "entry_value": "First discharge, during"
+                  "entry_value": "First discharge"
                 }
               ]
             },
@@ -360,12 +360,12 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Discharged Within or Outside ReportingPeriod ",
+              "entry_title": "Patient Discharged Within Reporting Period ",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "Second discharge, during"
+                  "entry_value": "Second discharge"
                 }
               ]
             },

--- a/resources/RT6/EP_RT6_G1.json
+++ b/resources/RT6/EP_RT6_G1.json
@@ -28,28 +28,28 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen Within or Outside Reporting/Performance Period ",
+              "entry_title": "Patient Seen Within Reporting/Performance Period ",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Lavon Earle",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Trula Covey",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Mai Nguyen",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Tom Warner",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Elsa Wu",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 }
               ]
             },
@@ -121,20 +121,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen Within or Outside Reporting/Performance Period ",
+              "entry_title": "Patient Seen Within Reporting/Performance Period ",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Trula Covey",
-                  "entry_value": "Second encounter, during"
+                  "entry_value": "Second encounter"
                 },
                 {
                   "patient_id": "Lavon Earle",
-                  "entry_value": "Second encounter, during"
+                  "entry_value": "Second encounter"
                 },
                 {
                   "patient_id": "Mai Nguyen",
-                  "entry_value": "Second encounter, during"
+                  "entry_value": "Second encounter"
                 }
               ]
             },
@@ -190,20 +190,20 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen Within or Outside Reporting/Performance Period ",
+              "entry_title": "Patient Seen Within Reporting/Performance Period ",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Alan Bench",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "Rashida Champagne",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 },
                 {
                   "patient_id": "David Brown",
-                  "entry_value": "First encounter, during"
+                  "entry_value": "First encounter"
                 }
               ]
             },
@@ -259,12 +259,12 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen Within or Outside Reporting/Performance Period ",
+              "entry_title": "Patient Seen Within Reporting/Performance Period ",
               "denom": true,
               "entry_values": [
                 {
                   "patient_id": "Elsa Wu",
-                  "entry_value": "Second encounter, during"
+                  "entry_value": "Second encounter"
                 }
               ]
             },

--- a/resources/RT6/EP_RT6_G2.json
+++ b/resources/RT6/EP_RT6_G2.json
@@ -41,7 +41,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen Within or Outside Reporting/Performance Period ",
+              "entry_title": "Patient Seen Within Reporting/Performance Period ",
               "denom": true,
               "entry_values": [
                 {
@@ -49,11 +49,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -62,11 +62,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -75,11 +75,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -88,7 +88,7 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
@@ -101,11 +101,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 }
@@ -290,7 +290,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen Within or Outside Reporting/Performance Period ",
+              "entry_title": "Patient Seen Within Reporting/Performance Period ",
               "denom": true,
               "entry_values": [
                 {
@@ -298,11 +298,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     }
                   ]
                 },
@@ -311,11 +311,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     }
                   ]
                 },
@@ -324,11 +324,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     }
                   ]
                 }
@@ -457,18 +457,18 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen Within or Outside Reporting/Performance Period",
+              "entry_title": "Patient Seen Within Reporting/Performance Period",
               "entry_values": [
                 {
                   "patient_id": "Alan Bench",
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -477,11 +477,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -490,11 +490,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 }
@@ -623,18 +623,18 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen Within or Outside Reporting/Performance Period",
+              "entry_title": "Patient Seen Within Reporting/Performance Period",
               "entry_values": [
                 {
                   "patient_id": "Margaret Wise",
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -643,11 +643,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 },
@@ -656,11 +656,11 @@
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     },
                     {
                       "provider": "Provider 2",
-                      "entry_value": "First encounter, during"
+                      "entry_value": "First encounter"
                     }
                   ]
                 }
@@ -789,14 +789,14 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Seen Within or Outside Reporting/Performance Period",
+              "entry_title": "Patient Seen Within Reporting/Performance Period",
               "entry_values": [
                 {
                   "patient_id": "Elsa Wu",
                   "providers": [
                     {
                       "provider": "Provider 1",
-                      "entry_value": "Second encounter, during"
+                      "entry_value": "Second encounter"
                     },
                     {
                       "provider": "Provider 2",

--- a/resources/RT7/EH_RT7_G1.json
+++ b/resources/RT7/EH_RT7_G1.json
@@ -35,7 +35,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Transition of Care or Referral Within or Outside Reporting Period",
+              "entry_title": "Transition of Care or Referral Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -166,7 +166,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Transition of Care or Referral Within or Outside Reporting Period",
+              "entry_title": "Transition of Care or Referral Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {

--- a/resources/RT7/EH_RT7_G2.json
+++ b/resources/RT7/EH_RT7_G2.json
@@ -36,7 +36,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Transition of Care or Referral Within or Outside Reporting Period",
+              "entry_title": "Transition of Care or Referral Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -174,7 +174,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Transition of Care or Referral Within or Outside Reporting Period",
+              "entry_title": "Transition of Care or Referral Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -282,7 +282,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Transition of Care or Referral Within or Outside Reporting Period",
+              "entry_title": "Transition of Care or Referral Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {

--- a/resources/RT8/EH_RT8_G1.json
+++ b/resources/RT8/EH_RT8_G1.json
@@ -38,23 +38,23 @@
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Allan Summers",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 }
               ]
             },
@@ -202,19 +202,19 @@
               "entry_values": [
                 {
                   "patient_id": "Anthony Edwards",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Bruce Hall",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Debra Steele",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Allan Summers",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 }
               ]
             },

--- a/resources/RT8/EH_RT8_G1.json
+++ b/resources/RT8/EH_RT8_G1.json
@@ -33,7 +33,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Admitted Within or Outside Reporting Period",
+              "entry_title": "Patient Admitted Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -197,7 +197,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Admitted Within or Outside Reporting Period",
+              "entry_title": "Patient Admitted Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {

--- a/resources/RT8/EH_RT8_G2.json
+++ b/resources/RT8/EH_RT8_G2.json
@@ -34,7 +34,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Admitted Within or Outside Reporting Period",
+              "entry_title": "Patient Admitted Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -205,7 +205,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Admitted Within or Outside Reporting Period",
+              "entry_title": "Patient Admitted Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -341,7 +341,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Admitted Within or Outside Reporting Period",
+              "entry_title": "Patient Admitted Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {

--- a/resources/RT8/EH_RT8_G2.json
+++ b/resources/RT8/EH_RT8_G2.json
@@ -39,23 +39,23 @@
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Allan Summers",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 }
               ]
             },
@@ -210,19 +210,19 @@
               "entry_values": [
                 {
                   "patient_id": "Anthony Edwards",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Bruce Hall",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Debra Steele",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Allan Summers",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 }
               ]
             },
@@ -346,19 +346,19 @@
               "entry_values": [
                 {
                   "patient_id": "Debra Price",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Mark Gordon",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Gabriel Brady",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Kirk Patterson",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 }
               ]
             },

--- a/resources/RT9/EH_RT9_G1.json
+++ b/resources/RT9/EH_RT9_G1.json
@@ -33,23 +33,23 @@
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Allan Summers",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 }
               ]
             },
@@ -190,19 +190,19 @@
               "entry_values": [
                 {
                   "patient_id": "Anthony Edwards",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Bruce Hall",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Debra Steele",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Allan Summers",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 }
               ]
             },

--- a/resources/RT9/EH_RT9_G1.json
+++ b/resources/RT9/EH_RT9_G1.json
@@ -28,7 +28,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Admitted Within or Outside Reporting Period",
+              "entry_title": "Patient Admitted Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -185,7 +185,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Admitted Within or Outside Reporting Period",
+              "entry_title": "Patient Admitted Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {

--- a/resources/RT9/EH_RT9_G2.json
+++ b/resources/RT9/EH_RT9_G2.json
@@ -29,7 +29,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Admitted Within or Outside Reporting Period",
+              "entry_title": "Patient Admitted Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -193,7 +193,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Admitted Within or Outside Reporting Period",
+              "entry_title": "Patient Admitted Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {
@@ -323,7 +323,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Patient Admitted Within or Outside Reporting Period",
+              "entry_title": "Patient Admitted Within Reporting Period",
               "denom": true,
               "entry_values": [
                 {

--- a/resources/RT9/EH_RT9_G2.json
+++ b/resources/RT9/EH_RT9_G2.json
@@ -34,23 +34,23 @@
               "entry_values": [
                 {
                   "patient_id": "Tracy Daniels",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Dianne Potter",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Katrina Owens",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Allan Summers",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Ada Mack",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 }
               ]
             },
@@ -198,19 +198,19 @@
               "entry_values": [
                 {
                   "patient_id": "Anthony Edwards",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Bruce Hall",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Debra Steele",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Allan Summers",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 }
               ]
             },
@@ -328,19 +328,19 @@
               "entry_values": [
                 {
                   "patient_id": "Debra Price",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Mark Gordon",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Gabriel Brady",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 },
                 {
                   "patient_id": "Kirk Patterson",
-                  "entry_value": "Admitted (EH/CAH), Within"
+                  "entry_value": "Admitted (EH/CAH)"
                 }
               ]
             },

--- a/resources/RT9/EP_RT9_G1.json
+++ b/resources/RT9/EP_RT9_G1.json
@@ -28,7 +28,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Transitioned, Referred, New, or Existing Patient Within Reporting/ Performance Period ",
+              "entry_title": "Transitioned, Referred, New, or Existing Patient Within Reporting / Performance Period ",
               "denom": true,
               "entry_values": [
                 {
@@ -185,7 +185,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Transitioned, Referred, New, or Existing Patient Within Reporting/ Performance Period ",
+              "entry_title": "Transitioned, Referred, New, or Existing Patient Within Reporting / Performance Period ",
               "denom": true,
               "entry_values": [
                 {

--- a/resources/RT9/EP_RT9_G2.json
+++ b/resources/RT9/EP_RT9_G2.json
@@ -40,7 +40,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Transitioned, Referred, New, or Existing Patient Within Reporting/ Performance Period ",
+              "entry_title": "Transitioned, Referred, New, or Existing Patient Within Reporting / Performance Period ",
               "denom": true,
               "entry_values": [
                 {
@@ -454,7 +454,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Transitioned, Referred, New, or Existing Patient Within Reporting/ Performance Period ",
+              "entry_title": "Transitioned, Referred, New, or Existing Patient Within Reporting / Performance Period ",
               "denom": true,
               "entry_values": [
                 {
@@ -778,7 +778,7 @@
             },
           "segment_entries": [
             {
-              "entry_title": "Transitioned, Referred, New, or Existing Patient Within Reporting/ Performance Period ",
+              "entry_title": "Transitioned, Referred, New, or Existing Patient Within Reporting / Performance Period ",
               "denom": true,
               "entry_values": [
                 {

--- a/resources/Start/EH_GeneralNotes_G1.json
+++ b/resources/Start/EH_GeneralNotes_G1.json
@@ -150,6 +150,11 @@
       "version_number": "2.3",
       "version_description": "Updated column headers in RT2a and RT2b to correctly specify View, Download, and Transmit.",
       "version_date": "5/5/2021"
+    },
+    {
+      "version_number": "2.4",
+      "version_description": "Added Guidance to hide Automated Drug Queries for 2021 RT1 tests for Medicare. Removed references to encounters that happen outside Reporting/Performance Period for RT1, RT2, RT3, RT4, RT5, RT6, RT7, RT8, RT9, RT10, RT11, RT12 and RT15.",
+      "version_date": "6/25/2021"
     }
   ]
 }

--- a/resources/Start/EH_GeneralNotes_G2.json
+++ b/resources/Start/EH_GeneralNotes_G2.json
@@ -155,6 +155,11 @@
       "version_number": "2.3",
       "version_description": "Updated column headers in RT2a and RT2b to correctly specify View, Download, and Transmit.",
       "version_date": "5/5/2021"
+    },
+    {
+      "version_number": "2.4",
+      "version_description": "Added Guidance to hide Automated Drug Queries for 2021 RT1 tests for Medicare. Removed references to encounters that happen outside Reporting/Performance Period for RT1, RT2, RT3, RT4, RT5, RT6, RT7, RT8, RT9, RT10, RT11, RT12 and RT15.",
+      "version_date": "6/25/2021"
     }
   ]
 }

--- a/resources/Start/EP_GeneralNotes_G1.json
+++ b/resources/Start/EP_GeneralNotes_G1.json
@@ -151,6 +151,11 @@
       "version_number": "2.3",
       "version_description": "Removed column in RT2b for Available to Access via API.",
       "version_date": "5/5/2021"
+    },
+    {
+      "version_number": "2.4",
+      "version_description": "Added Guidance to hide Automated Drug Queries for 2021 RT1 tests for MIPS. Removed references to encounters that happen outside Reporting/Performance Period for RT1, RT2, RT3, RT4, RT5, RT6, RT7, RT8, RT9, RT10, RT11, RT12 and RT15.",
+      "version_date": "6/25/2021"
     }
   ]
 }

--- a/resources/Start/EP_GeneralNotes_G2.json
+++ b/resources/Start/EP_GeneralNotes_G2.json
@@ -173,6 +173,11 @@
       "version_number": "2.3",
       "version_description": "Removed column in RT2b for Available to Access via API. Updated calculations for RT5.",
       "version_date": "5/5/2021"
+    },
+    {
+      "version_number": "2.4",
+      "version_description": "Added Guidance to hide Automated Drug Queries for 2021 RT1 tests for MIPS. Removed references to encounters that happen outside Reporting/Performance Period for RT1, RT2, RT3, RT4, RT5, RT6, RT7, RT8, RT9, RT10, RT11, RT12 and RT15.",
+      "version_date": "6/25/2021"
     }
   ]
 }


### PR DESCRIPTION
Added Guidance to hide Automated Drug Queries for 2021 RT1 tests for MIPS.
Removed references to encounters that happen outside Reporting/Performance Period for RT1, RT2, RT3, RT4, RT5, RT6, RT7, RT8, RT9, RT10, RT11, RT12 and RT15.